### PR TITLE
extend RealEstateObjectType with HBH

### DIFF
--- a/golang/domonda/realestateobject.go
+++ b/golang/domonda/realestateobject.go
@@ -119,6 +119,10 @@ const (
 	// RealEstateObjectTypeSEV represents a separate property management object
 	// (Sondereigentumsverwaltung)
 	RealEstateObjectTypeSEV RealEstateObjectType = "SEV"
+
+	// RealEstateObjectTypeHBH represents a general ledger / main bookkeeping object
+	// (Hauptbuchhaltung)
+	RealEstateObjectTypeHBH RealEstateObjectType = "HBH"
 )
 
 // Valid indicates if r is any of the valid values for RealEstateObjectType
@@ -132,7 +136,8 @@ func (r RealEstateObjectType) Valid() bool {
 		RealEstateObjectTypeMANDANT,
 		RealEstateObjectTypeMRG,
 		RealEstateObjectTypeMHV,
-		RealEstateObjectTypeSEV:
+		RealEstateObjectTypeSEV,
+		RealEstateObjectTypeHBH:
 		return true
 	}
 	return false
@@ -157,6 +162,7 @@ func (RealEstateObjectType) Enums() []RealEstateObjectType {
 		RealEstateObjectTypeMRG,
 		RealEstateObjectTypeMHV,
 		RealEstateObjectTypeSEV,
+		RealEstateObjectTypeHBH,
 	}
 }
 
@@ -171,6 +177,7 @@ func (RealEstateObjectType) EnumStrings() []string {
 		"MRG",
 		"MHV",
 		"SEV",
+		"HBH",
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `RealEstateObjectTypeHBH` ("HBH", Hauptbuchhaltung — general ledger / main bookkeeping object) to the `RealEstateObjectType` enum, including `Valid()`, `Enums()` and `EnumStrings()`.

## Why

`HBH` is already a valid option for `real_estate_object.type` on the finance backend (see migration `20260206100023_update_real_estate_object_types`: `{"WEG","HI","SUB","KREIS","MANDANT","MRG","MHV","SEV","HBH"}`), but it's missing from the Go SDK. This causes client-side validation (`RealEstateObjectType.Validate()`) to reject objects with type `HBH` before they reach the API, blocking import flows that need to map iX-Haus `Hauptbuchhaltung` objects to HBH.

## Changes

- Add `RealEstateObjectTypeHBH` constant
- Include `HBH` in `Valid()`, `Enums()`, `EnumStrings()`