### PR TITLE
docs: add MCP server documentation and per-client setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The Domonda API is a comprehensive platform for managing financial documents, in
 
 [**Go SDK**](#go-sdk) is available at [github.com/domonda/api/golang/domonda](https://pkg.go.dev/github.com/domonda/api/golang/domonda) for type-safe API interactions with client-side validation.
 
+> **New — AI assistant access (MCP).** You can now connect Claude, ChatGPT, and other AI assistants to your Domonda data through the new [MCP server](#mcp-server-ai-assistant-access): ask questions in plain language, read documents, invoices, and payments, and optionally upload files.
+
 ## Table of Contents
 
 1. [**Authentication**](#authentication)
@@ -31,7 +33,7 @@ The Domonda API is a comprehensive platform for managing financial documents, in
    * [Upload structured invoice data as JSON](#upload-structured-invoice-data-as-json)
    * [Upload company master data as JSON](#upload-company-master-data-as-json)
    * [Get document's custom fields](#get-documents-custom-fields)
-4. [**MCP Server (AI assistant access)**](#mcp-server-ai-assistant-access)
+4. [**MCP Server (AI assistant access)**](#mcp-server-ai-assistant-access) — **new**
 5. [**Go SDK**](#go-sdk)
    * [Installation](#installation)
    * [Usage examples](#usage-examples)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # DOMONDA API
 
-The Domonda API is a comprehensive platform for managing financial documents, invoices, and master data. It provides two complementary interfaces:
+The Domonda API is a comprehensive platform for managing financial documents, invoices, and master data. It provides three complementary interfaces:
 
 [**GraphQL**](#graphql-api) is the main API for querying data and changing single data items with mutations. Use this for reading documents, invoices, partners, and other entity data, as well as for making individual changes.
 
@@ -11,6 +11,8 @@ The Domonda API is a comprehensive platform for managing financial documents, in
 - Downloading document PDFs with audit trails
 - Bulk importing master data (partners, GL accounts, bank accounts, real estate objects)
 - Retrieving custom document fields
+
+[**MCP**](#mcp-server-ai-assistant-access) lets AI assistants (Claude, ChatGPT, and other MCP-capable agents) read your financial data and upload documents using natural language, over the Model Context Protocol.
 
 [**Authentication**](#authentication) is identical for both GraphQL and REST APIs and uses Bearer token authentication with API keys that provide access to a specific client company's data.
 
@@ -29,7 +31,8 @@ The Domonda API is a comprehensive platform for managing financial documents, in
    * [Upload structured invoice data as JSON](#upload-structured-invoice-data-as-json)
    * [Upload company master data as JSON](#upload-company-master-data-as-json)
    * [Get document's custom fields](#get-documents-custom-fields)
-4. [**Go SDK**](#go-sdk)
+4. [**MCP Server (AI assistant access)**](#mcp-server-ai-assistant-access)
+5. [**Go SDK**](#go-sdk)
    * [Installation](#installation)
    * [Usage examples](#usage-examples)
    * [Upload iDWELL CRM ticket](#put-idwell-crm-ticket)
@@ -1151,6 +1154,28 @@ Response:
   }
 ]
 ```
+
+## MCP Server (AI assistant access)
+
+The Domonda **Model Context Protocol (MCP)** server lets AI assistants —
+Claude, ChatGPT, and any MCP-capable agent — read your company's financial
+data and (optionally) upload documents, using natural language. It is a fourth
+interface alongside the GraphQL and REST APIs.
+
+The server speaks the [Model Context Protocol](https://modelcontextprotocol.io)
+over Streamable HTTP at:
+
+    https://domonda.app/api/mcp/
+
+**Authentication** uses the same Bearer API key as the GraphQL and REST APIs
+(see [Authentication](#authentication)), or an interactive OAuth sign-in for AI
+clients that support it. All query tools are read-only; the only write tool is
+`add_document`, which uploads a file through the same pipeline as the public
+REST upload endpoint.
+
+Full documentation, per-client setup guides (Claude Code, Claude Desktop,
+ChatGPT, OpenClaw), the tool reference, and curl examples are in
+**[`mcp/`](./mcp/)**.
 
 ## Go SDK
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -28,7 +28,7 @@ The trailing slash is optional — both `/api/mcp/` and `/api/mcp` work.
 - [Tools](#tools)
 - [Resources](#resources)
 - [curl examples](#curl-examples)
-- [Limits and security](#limits-and-security)
+- [Why access is limited](#why-access-is-limited)
 
 ## Quick start
 
@@ -256,15 +256,26 @@ curl -s -X POST "https://domonda.app/api/mcp/" \
   -d '{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"document://DOCUMENT_UUID/pdf"}}' | jq .
 ```
 
-## Limits and security
+## Why access is limited
 
-- **Read-only by default.** Every query tool runs in a `READ ONLY` database
-  transaction; only `add_document` writes, through the same OCR,
-  duplicate-detection, and category-ownership checks as the public REST upload.
-- **Tenant-scoped.** Every request is restricted to the authenticated client
-  company; a query can never reach another company's data.
-- **`api` schema only.** `execute_query` accepts `SELECT`/`WITH` against the
-  `api` schema; DML, DDL, and other schemas are rejected.
-- **Resource limits.** Max **1,000 rows** per query, a **30-second** query
-  timeout, **10,000-character** maximum SQL length, and a **10 MiB** maximum
-  response size.
+The MCP server is a deliberately narrow, safe window onto your data. The limits
+below exist to protect your data and keep responses fast and predictable — not
+to make the API harder to use.
+
+- **Read-only, so an assistant can explore freely.** Every tool except
+  `add_document` can only read. You can point an AI assistant at your data and
+  ask anything without worrying it will change, move, or delete a record. The
+  one write tool, `add_document`, goes through the same validation and
+  duplicate checks as a normal upload.
+- **Only ever your company's data.** Every request sees just the data of the
+  company its token belongs to. There is no way to phrase a question that
+  reaches another customer's data.
+- **A curated view, not the raw database.** Queries run against the documented
+  `api` schema — the same one behind the GraphQL and REST APIs — rather than
+  internal tables. Your queries keep working across product updates, and you
+  only ever see fields meant for you.
+- **Sized to stay fast.** A single request returns at most **1,000 rows**, runs
+  for at most **30 seconds**, accepts up to **10,000 characters** of SQL, and
+  returns up to **10 MiB**. These bounds stop one broad question from slowing
+  things down for you or anyone else — narrow with filters (date range, partner,
+  status) and paginate when you need more.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,270 @@
+# MCP Server (AI assistant access)
+
+The Domonda **Model Context Protocol (MCP)** server lets AI assistants —
+Claude, ChatGPT, and any MCP-capable agent — read your company's financial
+data and (optionally) upload documents, using natural language. It is a
+fourth interface alongside the [GraphQL](../README.md#graphql-api) and
+[REST](../README.md#rest-api) APIs and the [Go SDK](../README.md#go-sdk).
+
+The server speaks the [Model Context Protocol](https://modelcontextprotocol.io)
+over **Streamable HTTP**. All query tools are **read-only**; the single write
+tool is `add_document`, which uploads a file through the same pipeline as the
+public REST upload endpoint.
+
+| Environment | Base URL                       |
+|-------------|--------------------------------|
+| Production  | `https://domonda.app/api/mcp/` |
+
+The trailing slash is optional — both `/api/mcp/` and `/api/mcp` work.
+
+## Table of Contents
+
+- [Quick start](#quick-start)
+- [Authentication](#authentication)
+  - [OAuth flow](#oauth-flow)
+  - [Client ID Metadata Document (CIMD)](#client-id-metadata-document-cimd)
+  - [API key flow](#api-key-flow)
+- [Client setup guides](#client-setup-guides)
+- [Tools](#tools)
+- [Resources](#resources)
+- [curl examples](#curl-examples)
+- [Limits and security](#limits-and-security)
+
+## Quick start
+
+Point any MCP client at `https://domonda.app/api/mcp/` and authenticate with a
+Domonda API key (the same Bearer token used by the REST and GraphQL APIs) or by
+signing in via OAuth. Then jump to the guide for your client:
+
+- **[Claude Code](./claude-code/)** — Anthropic's CLI / IDE agent (native HTTP MCP)
+- **[Claude Desktop, Cowork & claude.ai](./claude-desktop/)** — Custom Connector UI
+- **[ChatGPT & OpenAI API](./chatgpt/)** — developer-mode connector + Responses API
+- **[OpenClaw](./openclaw/)** — OpenClaw skill / plugin
+
+## Authentication
+
+The MCP server uses **Bearer token** authentication. Two token types are
+supported:
+
+1. **API key (HS256 JWT)** — the **same** Domonda API key used by the REST and
+   GraphQL APIs (see the top-level
+   [Authentication section](../README.md#authentication)). The token's `sub`
+   claim identifies the client company directly. This is the simplest option
+   for programmatic access.
+2. **OAuth** — an access token obtained by signing in with your Domonda
+   account. The token is mapped to a Domonda user, who must be enabled and have
+   access to the target company. This is what interactive AI clients (Claude
+   Desktop, ChatGPT, …) obtain automatically.
+
+```
+Authorization: Bearer <DOMONDA_API_KEY_OR_OAUTH_TOKEN>
+```
+
+### OAuth flow
+
+Interactive MCP clients discover how to sign in automatically, following the
+OAuth 2.0 Protected Resource Metadata flow ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)):
+
+1. The client sends a request without an `Authorization` header (or with an
+   invalid token).
+2. The server responds `401 Unauthorized` with a `WWW-Authenticate` header
+   pointing at the protected-resource metadata:
+   ```
+   WWW-Authenticate: Bearer resource_metadata="https://domonda.app/api/mcp/.well-known/oauth-protected-resource"
+   ```
+3. The client fetches that metadata, discovers the authorization server, and
+   completes a standard OAuth 2.1 authorization-code flow with PKCE.
+4. The client retries with `Authorization: Bearer <access token>`.
+
+The `.well-known/oauth-protected-resource` and
+`.well-known/oauth-authorization-server` metadata endpoints are public; every
+other path requires authentication.
+
+To act on a client company other than your default, set the
+`X-Selected-Client-Company-ID` header to the target company UUID. The server
+verifies you have access before proceeding.
+
+### Client ID Metadata Document (CIMD)
+
+The server supports the
+[Client ID Metadata Document](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+mechanism from the 2025-11-25 MCP authorization spec, used by clients that
+identify themselves with an `https://` URL as their `client_id` (e.g. Claude
+and ChatGPT). No client registration step is required on your side — the server
+advertises CIMD support and registers the client transparently. Clients that do
+not use CIMD fall back to OAuth 2.0 Dynamic Client Registration
+([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)) automatically.
+
+### API key flow
+
+For programmatic access, send your Domonda API key as a Bearer token:
+
+```
+Authorization: Bearer <HS256-signed-JWT>
+```
+
+The JWT `sub` claim identifies the client company directly; no interactive
+sign-in is involved. This is the same key used by the REST and GraphQL APIs.
+
+## Client setup guides
+
+Step-by-step instructions, a tool reference (`SKILL.md`), and a
+`scripts/health_check.sh` connectivity check live in each client folder:
+
+- [`claude-code/`](./claude-code/) — Claude Code CLI / IDE (native HTTP MCP, no bridge)
+- [`claude-desktop/`](./claude-desktop/) — Claude Desktop, Cowork, and claude.ai (Custom Connector UI, with an `mcp-remote` fallback)
+- [`chatgpt/`](./chatgpt/) — ChatGPT developer-mode connector and the OpenAI Responses API / Agents SDK
+- [`openclaw/`](./openclaw/) — OpenClaw skill and plugin
+
+> **Tool descriptions are in German.** The tool and parameter descriptions the
+> server surfaces at runtime are written in German with Domonda domain
+> vocabulary (Sachkonto, Rechnung, Gutschrift, Geschäftspartner, …), because
+> end users chat in German. The English text in these guides is reference only.
+> When unsure which tool fits, call `list_capabilities` for a topic-grouped
+> catalog.
+
+## Tools
+
+### Discovery
+- **`list_capabilities`** — Topic-grouped catalog of all available tools
+
+### Schema introspection
+- **`list_tables`** — List tables/views in the `api` schema
+- **`describe_table`** — Describe columns of an `api` schema table/view
+
+### SQL query
+- **`execute_query`** — Execute a read-only SQL query (api schema only)
+
+### Documents
+- **`list_documents`** — List documents with filtering (archived, category, fulltext, dates, amounts, status, …)
+- **`get_document`** — Get a single document by ID (excludes `fulltext`)
+- **`get_document_fulltext`** — Get the extracted fulltext (OCR) of a document. **Can be very large.**
+- **`search_documents`** — Fulltext search across documents
+- **`download_document_pdf`** — Download a document PDF (optional audit trail)
+- **`get_document_thumbnail`** — Default JPEG thumbnail (256-wide)
+- **`get_document_preview`** — Preview image (964×1364 JPEG)
+- **`add_document`** — *(write)* Upload a document into the authenticated company
+
+### Invoices
+- **`list_invoices`** — List invoices with filtering (date range, partner, amounts)
+- **`get_invoice`** — Invoice details with line items and matched payments
+
+### Payments
+- **`list_money_accounts`** — List money accounts (bank, credit card, PayPal, …)
+- **`list_money_transactions`** — List money transactions with filtering
+- **`get_invoice_payments`** — Payment matches for a specific invoice
+
+### Company
+- **`get_my_company`** — Authenticated company joined with master data and headquarters
+- **`list_document_categories`** — List document categories
+- **`list_gl_accounts`** — List general ledger accounts
+- **`list_partner_companies`** — List/search partner companies
+
+### User
+- **`get_user`** — The authenticated user (OAuth only; API-key auth returns an error)
+
+### Workflows
+- **`list_document_workflows`** — Document workflows defined for the company
+- **`list_document_workflow_steps`** — Workflow steps (optionally filtered by `workflow_id`)
+- **`list_document_workflow_states`** — Current workflow step and state per document
+
+### App URLs
+- **`get_app_urls`** — Web-app deep links scoped to the authenticated company
+- **`get_document_urls`** — Web-app deep links for a single document
+- **`get_document_selection_url`** — Web-app deep links opening a selection of documents
+
+See each client folder's `SKILL.md` for the full parameter reference.
+
+## Resources
+
+The server advertises the `resources` capability via RFC 6570 URI templates.
+Each resource read runs through the same authentication and company-scoped
+ownership check as the tools.
+
+- **`document://{document_id}/thumb_256x0.jpeg`** — Default JPEG thumbnail (256-wide)
+- **`document://{document_id}/preview.jpeg`** — Preview image (964×1364 JPEG)
+- **`document://{document_id}/pdf{?audit_trail,audit_trail_lang}`** — Document PDF.
+  Optional query parameters: `audit_trail` (`append`, `prepend`, `only`) and
+  `audit_trail_lang` (ISO 639-1, default `de`).
+
+## curl examples
+
+The MCP server uses Streamable HTTP: all calls are `POST /api/mcp/` with a
+JSON-RPC body. Set your API key first:
+
+```bash
+ export DOMONDA_API_KEY="eyJhbGciOiJIUzI1NiIs..."   # leading space keeps this out of shell history
+```
+
+Discover the OAuth protected-resource metadata (public, no auth):
+
+```bash
+curl -s "https://domonda.app/api/mcp/.well-known/oauth-protected-resource" | jq .
+```
+
+Initialize a session / verify a token:
+
+```bash
+curl -s -X POST "https://domonda.app/api/mcp/" \
+  -H "Authorization: Bearer $DOMONDA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}' | jq .
+```
+
+List the available tools:
+
+```bash
+curl -s -X POST "https://domonda.app/api/mcp/" \
+  -H "Authorization: Bearer $DOMONDA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | jq .
+```
+
+List tables in the `api` schema:
+
+```bash
+curl -s -X POST "https://domonda.app/api/mcp/" \
+  -H "Authorization: Bearer $DOMONDA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_tables","arguments":{}}}' | jq .
+```
+
+Run a read-only SQL query:
+
+```bash
+curl -s -X POST "https://domonda.app/api/mcp/" \
+  -H "Authorization: Bearer $DOMONDA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"execute_query","arguments":{"sql":"SELECT id, title, document_date FROM api.document ORDER BY document_date DESC LIMIT 5"}}}' | jq .
+```
+
+List recent invoices:
+
+```bash
+curl -s -X POST "https://domonda.app/api/mcp/" \
+  -H "Authorization: Bearer $DOMONDA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_invoices","arguments":{"from_date":"2025-01-01","until_date":"2025-12-31","limit":10}}}' | jq .
+```
+
+Read a document PDF as an MCP resource:
+
+```bash
+curl -s -X POST "https://domonda.app/api/mcp/" \
+  -H "Authorization: Bearer $DOMONDA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"document://DOCUMENT_UUID/pdf"}}' | jq .
+```
+
+## Limits and security
+
+- **Read-only by default.** Every query tool runs in a `READ ONLY` database
+  transaction; only `add_document` writes, through the same OCR,
+  duplicate-detection, and category-ownership checks as the public REST upload.
+- **Tenant-scoped.** Every request is restricted to the authenticated client
+  company; a query can never reach another company's data.
+- **`api` schema only.** `execute_query` accepts `SELECT`/`WITH` against the
+  `api` schema; DML, DDL, and other schemas are rejected.
+- **Resource limits.** Max **1,000 rows** per query, a **30-second** query
+  timeout, **10,000-character** maximum SQL length, and a **10 MiB** maximum
+  response size.

--- a/mcp/chatgpt/README.md
+++ b/mcp/chatgpt/README.md
@@ -1,0 +1,283 @@
+# domonda MCP — ChatGPT & OpenAI API
+
+This directory contains setup instructions and configuration for connecting
+**ChatGPT** (developer-mode custom MCP connectors, sometimes surfaced as
+"apps") and the **OpenAI Responses API / Agents SDK** to the
+[domonda](https://domonda.app) financial data platform via its
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server.
+
+domonda's MCP server already implements everything ChatGPT requires of a remote
+MCP server — OAuth 2.1 with PKCE, RFC 9728 protected-resource metadata, RFC 8414
+authorization-server metadata, Client ID Metadata Documents (CIMD), and Dynamic
+Client Registration (DCR) — so **no server-side changes are needed** to connect
+ChatGPT. See the [main README](../README.md#authentication) for the protocol
+details.
+
+All query operations are **read-only**. The server exposes 28 tools covering
+documents, invoices, payments, money transactions, companies, GL accounts,
+partner companies, document workflows, web app deep links, ad-hoc SQL
+queries, and a `list_capabilities` discovery tool. The single write tool is
+`add_document`, which uploads a document via the same pipeline as the public
+upload endpoint.
+
+> **Live tool descriptions are in German.** The tool and parameter
+> descriptions surfaced by the running MCP server (and therefore what the
+> model actually matches against user prompts) are written in German with
+> domain vocabulary pulled from the domonda-app UI (Sachkonto, Rechnung,
+> Gutschrift, Geschäftspartner, Fälligkeitsdatum, Mandant, Freigabe, …) and
+> a "Nutzen wenn …" trigger-phrase block for each tool. End users chat in
+> German, so the descriptions are optimised for the words they actually
+> use. When uncertain which tool to call, call `list_capabilities` first for
+> a topic-grouped catalog.
+
+## Prerequisites
+
+- **For the ChatGPT app connector (Option 1):** a paid ChatGPT plan (Plus,
+  Pro, Business, Enterprise, or Edu) with **developer mode / custom MCP
+  connectors enabled**. On Business/Enterprise/Edu workspaces a workspace
+  owner or admin must enable it first. Authentication is **OAuth only** — the
+  ChatGPT UI has no field for pasting a static API key. See the
+  [OpenAI help article](https://help.openai.com/en/articles/12584461-developer-mode-apps-and-full-mcp-connectors-in-chatgpt-beta)
+  for the current plan-by-plan availability, as the UI changes frequently.
+- **For the OpenAI Responses API / Agents SDK (Options 2 & 3):** an OpenAI API
+  key, plus either a domonda API key (JWT — obtain from the domonda admin
+  panel) or an Auth0 OAuth access token for the MCP resource.
+- `curl` (for the health check script).
+
+## Directory Structure
+
+```
+chatgpt/
+├── SKILL.md                          # Skill / tool reference (frontmatter + tool docs)
+├── openai_responses_mcp.json.example # Example `mcp` tool object for the Responses API
+├── scripts/
+│   └── health_check.sh               # Connectivity check script
+└── README.md                         # This file
+```
+
+> The ChatGPT app connector (Option 1) is configured entirely in the ChatGPT
+> UI, so it has no config file. The `.example` file is for the API path only.
+
+## Setup — pick one of three paths
+
+### Option 1 — ChatGPT developer-mode connector (recommended, OAuth)
+
+The connector originates from OpenAI's cloud and dials the MCP endpoint on your
+behalf — so it needs a **publicly reachable** URL and drives an OAuth sign-in.
+
+1. **Enable developer mode.** On Plus/Pro: **Settings → Connectors → Advanced →
+   Developer mode**. On Business/Enterprise/Edu: a workspace owner/admin enables
+   it under workspace settings (Permissions & Roles → Connected data → custom
+   MCP connectors), then individual members enable it under their own
+   **Settings → Connectors → Advanced**.
+2. Open **Settings → Connectors → Add custom connector** (labelled **Create** in
+   some builds).
+3. Enter the MCP URL: `https://domonda.app/api/mcp/`
+4. Complete the authentication prompt. domonda serves the Auth0 OAuth discovery
+   metadata (`.well-known/oauth-protected-resource` per RFC 9728), so ChatGPT
+   redirects you to Auth0 to sign in and registers itself via CIMD (preferred)
+   or DCR automatically — no client ID or secret to enter.
+5. Start a new chat and confirm the domonda tools appear in the connector / tool
+   picker.
+
+> **Doesn't work for localhost.** Because the connector dials from OpenAI's
+> cloud, `http://localhost:5001/mcp/` is unreachable. Use Option 2 or 3 against
+> your local server, or expose it with a tunnel (e.g. ngrok) over HTTPS.
+>
+> **OAuth only.** The UI has no raw-Bearer-JWT field. To use a static domonda
+> API key, use the API paths below.
+
+### Option 2 — OpenAI Responses API (programmatic, API key or OAuth)
+
+The Responses API connects to remote MCP servers over Streamable HTTP. Add an
+`mcp` tool pointing at the domonda endpoint and pass the bearer token in
+`headers`. See `openai_responses_mcp.json.example` for the ready-to-paste tool
+object.
+
+```python
+from openai import OpenAI
+import os
+
+client = OpenAI()  # reads OPENAI_API_KEY
+
+response = client.responses.create(
+    model="gpt-5",
+    tools=[
+        {
+            "type": "mcp",
+            "server_label": "domonda",
+            "server_url": "https://domonda.app/api/mcp/",
+            "headers": {"Authorization": f"Bearer {os.environ['DOMONDA_API_KEY']}"},
+            "require_approval": "never",
+        },
+    ],
+    input="Show me the 5 most recent invoices over €1,000.",
+)
+print(response.output_text)
+```
+
+> OpenAI discards the header values after each request, so the
+> `Authorization` header must be included with **every** API call. A domonda
+> API key (HS256 JWT) works directly here; an Auth0 OAuth access token works
+> too.
+
+### Option 3 — OpenAI Agents SDK (programmatic)
+
+```python
+import os
+from agents import Agent, Runner
+from agents.mcp import MCPServerStreamableHttp
+
+async def main():
+    async with MCPServerStreamableHttp(
+        name="domonda",
+        params={
+            "url": "https://domonda.app/api/mcp/",
+            "headers": {"Authorization": f"Bearer {os.environ['DOMONDA_API_KEY']}"},
+        },
+        cache_tools_list=True,
+    ) as server:
+        agent = Agent(
+            name="Assistant",
+            instructions="Use the domonda tools to answer.",
+            mcp_servers=[server],
+        )
+        result = await Runner.run(agent, "Which GL accounts are in use?")
+        print(result.final_output)
+```
+
+## How ChatGPT registers as an OAuth client
+
+For the Option 1 connector, ChatGPT needs to register itself as an OAuth client
+with domonda's authorization server. domonda advertises everything ChatGPT
+checks for, so registration is automatic:
+
+- **CIMD (preferred).** ChatGPT uses an `https://` URL as its `client_id`;
+  domonda fetches that document and registers the client with Auth0 via DCR on
+  ChatGPT's behalf. Selected automatically because domonda's
+  authorization-server metadata advertises `"client_id_metadata_document_supported": true`
+  and `"none"` in `token_endpoint_auth_methods_supported`.
+- **DCR (fallback, RFC 7591).** ChatGPT calls domonda's `/register` endpoint
+  (proxied to Auth0) once per connector instance.
+- **PKCE (S256)** is mandatory and advertised via
+  `"code_challenge_methods_supported": ["S256"]`.
+
+No client ID or secret is entered in the ChatGPT UI. See the
+[main README CIMD / DCR sections](../README.md#client-id-metadata-document-cimd)
+for the full flow and the Auth0 setup it depends on.
+
+### Base URL: production vs local
+
+In production the domonda-web-server is mounted behind an `/api` path prefix,
+so the MCP endpoint is `https://domonda.app/api/mcp/`. When running the web
+server locally there is **no** `/api` prefix — use `http://localhost:5001/mcp/`
+(5001 is the default port; override with `PORT=…`). The ChatGPT app connector
+cannot reach localhost (see Option 1); the API paths can.
+
+## Verify Connectivity
+
+### Health check script
+
+```bash
+ export DOMONDA_API_KEY="your-api-key-here"   # leading space keeps this out of shell history
+./scripts/health_check.sh
+```
+
+Expected output:
+
+```
+Checking https://domonda.app/api/mcp/ ...
+OK (HTTP 200)
+```
+
+### Inside ChatGPT
+
+Start a new conversation with the connector enabled and ask:
+
+> "Use the domonda tools to get company info."
+
+ChatGPT should call `get_my_company` and return your company details.
+
+## Usage
+
+Once connected, the model can call any of the 28 domonda tools. See `SKILL.md`
+for the complete tool reference with parameters.
+
+### Recommended first steps
+
+1. **`list_capabilities`** — When unsure which tool fits, get a grouped
+   catalog of all available tools first.
+2. **`get_my_company`** — Confirm authentication and see which company the
+   token is scoped to.
+3. **`list_tables`** / **`describe_table`** — Explore the available database
+   schema before writing queries.
+4. **`list_documents`** or **`list_invoices`** — Browse recent data.
+5. **`execute_query`** — Run ad-hoc read-only SQL for anything the specialized
+   tools don't cover.
+
+### Tool categories
+
+| Category  | Tools                                                                                                                                                                      |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Discovery | `list_capabilities`                                                                                                                                                        |
+| Schema    | `list_tables`, `describe_table`                                                                                                                                            |
+| Query     | `execute_query`                                                                                                                                                            |
+| Documents | `list_documents`, `get_document`, `get_document_fulltext`, `search_documents`, `download_document_pdf`, `get_document_thumbnail`, `get_document_preview`, `add_document` (write) |
+| Invoices  | `list_invoices`, `get_invoice`                                                                                                                                             |
+| Payments  | `list_money_accounts`, `list_money_transactions`, `get_invoice_payments`                                                                                                   |
+| Company   | `get_my_company`, `list_document_categories`, `list_gl_accounts`, `list_partner_companies`                                                                                 |
+| User      | `get_user`                                                                                                                                                                 |
+| Workflows | `list_document_workflows`, `list_document_workflow_steps`, `list_document_workflow_states`                                                                                 |
+| App URLs  | `get_app_urls`, `get_document_urls`, `get_document_selection_url`                                                                                                          |
+
+### Example prompts
+
+- "Show me all invoices from January 2026 over €1,000"
+- "Download the PDF for document 8a2f..."
+- "Which GL accounts are in use?"
+- "Search documents for 'electricity bill'"
+- "Run a query to find the top 10 partners by invoice count"
+- "Upload this invoice PDF into the OTHER_DOCUMENTS category"
+
+## Authentication
+
+The domonda MCP server uses **Streamable HTTP** transport with **Bearer token**
+authentication. Two token types are supported:
+
+1. **API key (HS256 JWT)** — the standard domonda API key. The JWT `sub` claim
+   identifies the client company directly. Use it in the Responses API / Agents
+   SDK `headers` (Options 2 & 3). The ChatGPT app connector UI does **not**
+   accept it.
+2. **OAuth (Auth0 RS256)** — an Auth0 access token issued for the MCP resource.
+   The token's Auth0 `sub` claim is mapped to a Domonda user, who must be
+   enabled and have access to the target company. This is what the ChatGPT app
+   connector (Option 1) obtains automatically. Supports the
+   `X-Selected-Client-Company-ID` header for multi-company users.
+
+```
+Authorization: Bearer <DOMONDA_API_KEY_OR_OAUTH_TOKEN>
+```
+
+The server enforces:
+
+- **Read-only transactions for query tools** — no INSERT, UPDATE, DELETE, or DDL
+- **Schema restriction** — only the `api` schema is accessible
+- **Row limit** — max 1,000 rows per query
+- **Query timeout** — 30-second default
+- **Query length** — max 10,000 characters
+- **Writes are limited to `add_document`** — processed through the same OCR,
+  duplicate-detection, and category-ownership checks as the public API
+
+## Troubleshooting
+
+| Symptom                                          | Cause                                                        | Fix                                                                                  |
+|--------------------------------------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| No "Add custom connector" / "Create" option      | Developer mode not enabled, or plan/workspace doesn't allow it | Enable developer mode (Settings → Connectors → Advanced); on workspaces ask an admin |
+| Connector can't reach `localhost:…`              | Connector dials from OpenAI's cloud, not your machine        | Use Option 2/3, or expose the local server over HTTPS via a tunnel                    |
+| No place to paste an API key in ChatGPT          | The app connector UI is OAuth-only                           | Use the Responses API / Agents SDK (Options 2 & 3) for a static Bearer JWT            |
+| OAuth sign-in loops or fails                     | Auth0 DCR/CIMD prerequisites missing on the tenant           | See the main README "DCR and CIMD" Auth0 setup steps                                  |
+| HTTP 401                                         | Invalid, expired, or blocked token                           | Verify your API key or OAuth token; contact admin if blocked                         |
+| HTTP 403                                         | Forbidden company access or insufficient OAuth scopes        | Check the selected company or required scopes                                        |
+| HTTP 404                                         | Wrong endpoint URL                                           | Ensure the URL ends with `/mcp/` or `/mcp` (production: `/api/mcp/`)                  |
+| Query returns no rows                            | Company scoping — data belongs to another company           | Confirm `get_my_company` returns the expected company                                |
+| `execute_query` rejected                         | SQL validation failed (DML, wrong schema)                   | Use only SELECT/WITH against the `api` schema                                        |

--- a/mcp/chatgpt/SKILL.md
+++ b/mcp/chatgpt/SKILL.md
@@ -1,0 +1,567 @@
+---
+name: domonda
+description: >
+  Use when you need to access domonda financial data — documents, invoices,
+  payments, money transactions, companies, GL accounts, partner companies,
+  and document workflows. Connects to the domonda MCP server via Streamable
+  HTTP with Bearer token authentication (API key or OAuth). All query tools
+  are read-only; the only write tool is `add_document`, which uploads a file
+  into the authenticated company's document pipeline.
+env:
+  - name: DOMONDA_API_KEY
+    required: true
+    secret: true
+    description: API key (HS256 JWT) or Auth0 OAuth access token for Bearer authentication
+  - name: DOMONDA_URL
+    required: false
+    secret: false
+    description: "Override domonda base URL (default: https://domonda.app)"
+---
+
+# domonda MCP Skill
+
+Connect to the [domonda](https://domonda.app) financial data platform via its MCP server.
+Query documents, invoices, payments, money transactions, companies, GL accounts, partner companies, and document workflows. All query tools are read-only; the only write tool is `add_document`, which uploads a file into the authenticated company's document pipeline.
+
+> **Language note.** The live MCP tool and parameter descriptions surfaced by
+> the server are written in **German**, including a "Nutzen wenn …" block of
+> trigger phrases. This matches the domonda-app UI and the natural vocabulary
+> of end users, and improves discoverability for clients (e.g. ChatGPT) that
+> match user prompts against tool descriptions by embedding similarity. The
+> English descriptions in this file are developer-facing reference only —
+> what your agent actually sees at runtime is the German text from the server.
+>
+> If you are unsure which tool to call, call `list_capabilities` first to get
+> a topic-grouped catalog of all available tools.
+
+## Agent Security Rules
+
+- **Never** display, log, or transmit the API key in plain text.
+- **Never** pass the API key as a CLI argument or embed it in URLs.
+- Only use the API key for authenticating against the domonda MCP endpoint.
+- Do not write, modify, or delete data via `execute_query` or any query tool — those tools are read-only and any DML will be rejected by the server.
+- The only write tool is `add_document`. Only call it when the user has explicitly asked you to upload a document. Never call it on your own initiative, and never use it to write arbitrary data.
+
+## Quick Start
+
+Pick one of:
+
+**a. ChatGPT developer-mode connector (recommended, OAuth):**
+
+1. A workspace **admin** enables developer mode / custom MCP connectors
+   (Settings → Connectors → Advanced → Developer mode).
+2. In ChatGPT: **Settings → Connectors → Add custom connector** (or **Create**).
+3. URL: `https://domonda.app/api/mcp/`
+4. Complete the Auth0 OAuth sign-in prompt — ChatGPT discovers the flow via
+   RFC 9728 metadata and registers itself via CIMD/DCR automatically. There is
+   **no** raw-API-key field in the ChatGPT UI; use path **b** for a static key.
+
+**b. OpenAI Responses API / Agents SDK (programmatic, API key):**
+
+Pass the domonda MCP endpoint as an `mcp` tool with a Bearer header:
+
+```json
+{
+  "type": "mcp",
+  "server_label": "domonda",
+  "server_url": "https://domonda.app/api/mcp/",
+  "headers": { "Authorization": "Bearer YOUR_API_KEY_HERE" },
+  "require_approval": "never"
+}
+```
+
+Verify endpoint connectivity first with:
+
+```bash
+./scripts/health_check.sh
+```
+
+See `README.md` for full setup, plans, and troubleshooting.
+
+## Available Tools
+
+> The description paragraph for each tool below is written in **German**
+> (matching what the running MCP server actually surfaces to clients),
+> because domonda end users chat in German and tools are picked by
+> similarity to the user's prompt. The parameter tables and technical
+> notes stay in English.
+
+### Discovery
+
+#### `list_capabilities`
+
+Liefert einen nach Thema gruppierten Katalog ALLER verfügbaren Domonda-Tools
+mit einer kurzen deutschen Einzeiler-Beschreibung pro Tool. Dient als
+Einstiegspunkt: bei Unsicherheit, welches Tool passt, zuerst dieses
+aufrufen und dann das passende Tool direkt nutzen. Nutzen wenn der Benutzer
+nach "was kannst du", "welche Tools", "welche Werkzeuge", "hilf mir",
+"Übersicht", "Katalog", "was ist verfügbar", "Capabilities", "Hilfe" fragt.
+
+**Parameters:** None
+
+### Schema Tools
+
+#### `list_tables`
+
+Listet alle Tabellen und Views im `api`-Schema der Domonda-Datenbank (Name,
+Typ Tabelle/View, Beschreibung). Nutzen für Datenmodell-Exploration, bevor
+eine benutzerdefinierte Abfrage via `execute_query` gebaut wird, oder wenn
+der Benutzer nach "welche Tabellen gibt es", "Datenmodell", "Schema", "was
+ist in der DB" fragt.
+
+**Parameters:** None
+
+#### `describe_table`
+
+Beschreibt die Spalten einer Tabelle oder View im `api`-Schema:
+Spaltennamen, Datentypen, NULL-Zulässigkeit, Default-Werte. Nutzen bevor
+eine `SELECT`-Abfrage via `execute_query` geschrieben wird, um die
+verfügbaren Spalten zu kennen, oder wenn der Benutzer nach "welche
+Spalten", "Struktur der Tabelle", "Felder" fragt.
+
+| Parameter    | Type   | Required | Description                                                                                     |
+|------------- |--------|----------|-------------------------------------------------------------------------------------------------|
+| `table_name` | string | yes      | Name of the table or view in the `api` schema (e.g. `invoice`, `document`, `partner_company`)   |
+
+### Query Tools
+
+#### `execute_query`
+
+Führt eine READ-ONLY SQL-Abfrage (`SELECT` oder `WITH`) gegen das
+`api`-Schema der Domonda-Datenbank aus. Nur das `api`-Schema ist zugänglich;
+`pg_catalog`, `information_schema` und andere Schemata werden abgelehnt.
+Unqualifizierte Tabellennamen werden ins `api`-Schema aufgelöst. Ergebnis:
+JSON-Array von Objekten, maximal 1000 Zeilen. Daten sind automatisch auf
+den angemeldeten Mandanten eingeschränkt. Nutzen nur wenn die
+spezialisierten Tools (`list_documents`, `list_invoices`,
+`list_money_transactions`, …) nicht ausreichen und eine eigene Abfrage
+nötig ist. Vorher `list_tables` und `describe_table` nutzen, um das Schema
+zu erkunden.
+
+| Parameter | Type   | Required | Description                                                                                        |
+|-----------|--------|----------|----------------------------------------------------------------------------------------------------|
+| `sql`     | string | yes      | The SQL query to execute. Must start with `SELECT` or `WITH`. Only the `api` schema is accessible. |
+
+### Document Tools
+
+#### `list_documents`
+
+Sucht, filtert und listet Dokumente des Mandanten: Rechnungen, Verträge,
+Belege, Lieferscheine, Kontoauszüge, sonstige Dokumente, DMS. Unterstützt
+Volltextsuche, Datumsbereiche (mehrere Datumstypen), Beträge, Zahl- und
+Exportstatus, Geschäftspartner, Kategorien, Dokumentarten,
+Genehmigungsstatus, Duplikate, Kommentare, Vertragstypen und konfigurierbare
+Sortierung. Nutzen wenn der Benutzer nach "Dokumente", "Belege",
+"Rechnungen", "Verträge", "Lieferscheine", "Kontoauszüge", "Mahnungen",
+"was liegt im Eingang", "Dokumentenliste", "welche Dokumente gibt es zu …",
+"suche Beleg über …", "offene Rechnungen", "nicht freigegebene", "nicht
+exportierte" fragt. Für reine Volltextsuche ohne Filter siehe
+`search_documents`.
+
+All filter parameters are optional; omitting a parameter lets the server default apply.
+
+| Parameter                | Type            | Description                                                                                                               |
+|--------------------------|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| `limit`                  | number          | Maximum number of documents to return (default 50, max 1000)                                                              |
+| `offset`                 | number          | Number of documents to skip for pagination                                                                                |
+| `search_text`            | string          | Fulltext search over the extracted document content (OCR + structured data)                                               |
+| `archived`               | string enum     | `exclude` (default, only active), `only` (only archived), or `include` (both)                                             |
+| `has_warning`            | boolean         | `true`: only documents with a warning; `false`: only documents without                                                    |
+| `internal_number`        | string          | Filter by domonda-internal sequential document number                                                                     |
+| `date_filter_type`       | string enum     | Which date `from_date`/`until_date` apply to: `DOCUMENT_DATE`, `INVOICE_DATE` (default), `IMPORT_DATE`, `DUE_DATE`, `DISCOUNT_DUE_DATE`, `PAID_DATE`, `DELIVERED_DATE` |
+| `from_date`              | string          | Lower bound (inclusive) for the date selected via `date_filter_type` (YYYY-MM-DD)                                         |
+| `until_date`             | string          | Upper bound (inclusive) for the date selected via `date_filter_type` (YYYY-MM-DD)                                         |
+| `min_total`              | number          | Only documents with invoice gross total ≥ this amount                                                                     |
+| `max_total`              | number          | Only documents with invoice gross total ≤ this amount                                                                     |
+| `export_status`          | string enum     | Accounting export status (exported / not exported, for "booking" or "ready for booking"; see tool schema for the full enum) |
+| `paid_status`            | string enum     | Invoice payment status: paid, partially paid, not paid, not payable, or paid via a specific payment method                 |
+| `document_types`         | string[] enum   | One or more document types (incoming/outgoing invoice, dunning letter, delivery note, bank/credit-card statement, other document, DMS, …) |
+| `document_category_ids`  | string[] (UUID) | One or more document category IDs (from `list_document_categories`)                                                        |
+| `partner_company_ids`    | string[] (UUID) | One or more partner company IDs (customer or supplier, from `list_partner_companies`)                                      |
+| `is_credit_memo`         | boolean         | `true`: only credit memos (Gutschriften); `false`: exclude credit memos                                                    |
+| `has_pain001_payment`    | boolean         | `true`: only documents with a generated SEPA credit transfer (PAIN.001); `false`: without                                  |
+| `has_pain008_direct_debit` | boolean       | `true`: only documents with a generated SEPA direct debit (PAIN.008); `false`: without                                     |
+| `is_payment_reminder_sent` | boolean       | `true`: only documents for which a payment reminder/dunning letter has already been sent                                   |
+| `is_approved`            | boolean         | `true`: only approved documents; `false`: only not-yet-approved documents (waiting for workflow approval)                  |
+| `is_duplicate`           | boolean         | `true`: only documents detected as duplicates; `false`: only non-duplicates                                                |
+| `has_comments`           | boolean         | `true`: only documents with comments; `false`: without                                                                     |
+| `is_recurring`           | boolean         | `true`: only recurring documents; `false`: only one-off documents                                                          |
+| `contract_type`          | string enum     | Contract type filter for `OTHER_DOCUMENT`s (service contracts, rental contracts, insurance, …; see tool schema)            |
+| `order_bys`              | string[] enum   | Ordering rules applied in sequence; default `IMPORT_DATE_DESC` (most recently imported first)                              |
+
+> The full enum values for `export_status`, `paid_status`, `document_types`, `contract_type`, and `order_bys` are exposed on the live tool schema — your MCP client will surface them.
+
+#### `get_document`
+
+Liefert Metadaten eines einzelnen Dokuments anhand seiner UUID: Dokumentart,
+Kategorie, Geschäftspartner, Datum, Status, Beträge (soweit vorhanden).
+Enthält **nicht** den Volltext — siehe `get_document_fulltext` für den
+extrahierten OCR-Text oder `get_invoice` für Rechnungs-Positionen. Nutzen
+wenn der Benutzer nach "Details zum Dokument", "Info zu diesem Beleg", "was
+ist das für ein Dokument", "wer hat das hochgeladen", "welche Kategorie"
+fragt.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_fulltext`
+
+Liefert den extrahierten Volltext (OCR) eines Dokuments. Nutzen wenn der
+Benutzer den kompletten Inhalt eines Dokuments lesen will — "Volltext",
+"was steht im Beleg", "OCR-Text", "Inhalt dieses Dokuments".
+
+**Warning:** fulltexts can be very large; long documents may approach or
+exceed the MCP response byte cap (default 10 MiB)
+and the call will fail. For pure search prefer `search_documents` and only
+fetch the fulltext of a specific hit when really needed.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `search_documents`
+
+Volltextsuche über alle Dokumente des Mandanten; Treffer sind nach Relevanz
+sortiert. Nutzen wenn der Benutzer etwas FINDEN will, statt gezielt zu
+filtern — z. B. "finde Beleg über Büromöbel", "such mir alles zu Projekt
+X", "gibt es eine Rechnung mit …", "wo taucht der Begriff … auf". Für
+strukturierte Filter (Datum, Partner, Status, Beträge) lieber
+`list_documents` verwenden.
+
+| Parameter | Type   | Required | Description                                          |
+|-----------|--------|----------|------------------------------------------------------|
+| `query`   | string | yes      | Search term or phrase for the fulltext search        |
+| `limit`   | number | no       | Maximum number of results (default: 20, max: 1000)   |
+
+#### `download_document_pdf`
+
+Lädt die Original-PDF-Datei eines Dokuments herunter — optional mit
+angehängtem oder vorangestelltem Audit-Trail (Protokoll der
+Bearbeitungsschritte, Freigaben, Änderungen). Standard: die PDF-Bytes
+werden base64-kodiert inline zurückgegeben. Mit `inline: false` wird
+stattdessen ein MCP `resource_link` auf `document://{document_id}/pdf?...`
+geliefert, den ein resource-fähiger Client via `resources/read` nachladen
+kann. Nutzen wenn der Benutzer "die PDF", "das Original", "den Beleg
+herunterladen", "Rechnung als PDF", "mit Audit-Trail" sagt.
+
+| Parameter          | Type    | Required | Description                                                                        |
+|--------------------|---------|----------|------------------------------------------------------------------------------------|
+| `document_id`      | string  | yes      | The UUID of the document                                                           |
+| `audit_trail`      | string  | no       | Audit-trail position in the PDF: `append`, `prepend`, `configured` (mandant setting), or `only` (audit trail only). Empty = no audit trail. |
+| `audit_trail_lang` | string  | no       | Language of the audit trail as ISO 639-1 code (default `de`)                       |
+| `inline`           | boolean | no       | `true` (default): return the PDF bytes inline as a base64-encoded resource. `false`: return an MCP `resource_link` to `document://{document_id}/pdf?...` that a resource-aware client loads via `resources/read`. |
+
+The PDF is also exposed as an MCP resource at `document://{document_id}/pdf{?audit_trail,audit_trail_lang}`, so resource-aware clients can fetch it via `resources/read`. The `configured` audit-trail value is resolved to `append`/`prepend` before a resource link is returned, so resource URIs are deterministic and cacheable.
+
+#### `get_document_thumbnail`
+
+Liefert die kleine Miniaturansicht (JPEG, 256 px breit, Seitenverhältnis
+erhalten) eines Dokuments als base64-kodierten Blob. Auch als MCP-Ressource
+unter `document://{document_id}/thumb_256x0.jpeg` verfügbar. Nutzen wenn
+der Benutzer eine schnelle Vorschau, ein Miniaturbild oder ein "Icon" eines
+Dokuments sehen will. Für eine größere Vorschau siehe `get_document_preview`.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_preview`
+
+Liefert die große Vorschau (JPEG, 964×1364) eines Dokuments als
+base64-kodierten Blob — das größte vorgerenderte Vorschaubild. Auch als
+MCP-Ressource unter `document://{document_id}/preview.jpeg` verfügbar.
+Nutzen wenn der Benutzer "zeig mir das Dokument", "Vorschau", "wie sieht
+der Beleg aus", "Bild des Dokuments" sagt. Für eine kleinere Miniaturansicht
+siehe `get_document_thumbnail`; für die Original-PDF siehe
+`download_document_pdf`.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `add_document` (write)
+
+Lädt ein neues Dokument (Rechnung, Beleg, Vertrag, Lieferschein, sonstige
+Datei) für den angemeldeten Mandanten hoch. Dubletten-Erkennung und
+Kategorie-Zuweisung laufen automatisch. Nutzen wenn der Benutzer "Dokument
+hochladen", "Beleg importieren", "Rechnung hinzufügen", "upload", "neues
+Dokument", "Datei einspielen" sagt. Vorher `list_document_categories`
+aufrufen, um eine gültige `category_id` zu ermitteln.
+
+Supported file types: PDF, PNG, JPEG, TIFF, XML, HTML, RTF, DOC, DOCX, ODT,
+XLS, XLSX, ODS. This is the **only write operation** on the MCP server; the
+file is processed through the same pipeline as the public upload endpoint.
+Returns the new document UUID on success.
+
+| Parameter                 | Type    | Required | Description                                                                                |
+|---------------------------|---------|----------|--------------------------------------------------------------------------------------------|
+| `file_data`               | string  | yes      | Base64-encoded file content (no URL, no path — the raw bytes base64-encoded)                |
+| `filename`                | string  | yes      | Original filename including extension (e.g. `invoice_2026_04.pdf`)                         |
+| `category_id`             | string  | yes      | Document category UUID (use `list_document_categories` to find valid IDs)                  |
+| `tags`                    | string[]| no       | Optional document tags                                                                     |
+| `allow_duplicate_deleted` | boolean | no       | If `true`, allow re-uploading a file whose hash matches a previously-deleted document. Default `false`. |
+| `wait_for_extraction`     | boolean | no       | If `true`, wait synchronously for OCR/extraction before returning. Default `false` (asynchronous). |
+
+> **Agent guidance:** Only call `add_document` when the user has explicitly asked you to upload a file. Do not use it on your own initiative.
+
+### Invoice Tools
+
+#### `list_invoices`
+
+Listet Rechnungen des Mandanten (Eingangs- und Ausgangsrechnungen, inkl.
+Gutschriften) mit Rechnungsnummer, Rechnungsdatum, Fälligkeitsdatum,
+Geschäftspartner, Netto, Brutto, Währung, USt-Satz, Zahlstatus, offenem
+Betrag und Buchungsstatus. Filter: Datumsbereich, Partner-Name,
+Mindest-/Maximalbetrag. Nutzen wenn der Benutzer nach "Rechnungen",
+"Eingangsrechnungen", "Ausgangsrechnungen", "ER", "AR", "Gutschriften",
+"offene Posten", "Forderungen", "Verbindlichkeiten", "unbezahlte
+Rechnungen", "Rechnungen von <Firma>" fragt. Für einzelne Rechnungsdetails
+siehe `get_invoice`.
+
+| Parameter      | Type   | Required | Description                                                                                                  |
+|----------------|--------|----------|--------------------------------------------------------------------------------------------------------------|
+| `limit`        | number | no       | Maximum number of invoices to return (default: 50, max: 1000)                                                |
+| `offset`       | number | no       | Number of invoices to skip for pagination (default: 0)                                                       |
+| `from_date`    | string | no       | Lower bound (inclusive) for the invoice date (YYYY-MM-DD)                                                    |
+| `until_date`   | string | no       | Upper bound (inclusive) for the invoice date (YYYY-MM-DD)                                                    |
+| `partner_name` | string | no       | Filter by partner company name (customer or supplier, case-insensitive partial match)                        |
+| `min_total`    | number | no       | Only invoices with gross total ≥ this amount                                                                 |
+| `max_total`    | number | no       | Only invoices with gross total ≤ this amount                                                                 |
+
+#### `get_invoice`
+
+Liefert alle Details zu einer einzelnen Rechnung: Kopfdaten, Positionen
+(Line Items), Skonto, Fälligkeit, umgerechnete EUR-Beträge, Geschäftspartner,
+UID/VAT-ID des Partners, zugeordnete Zahlungen. Nutzen wenn der Benutzer
+eine konkrete Rechnung im Detail sehen will — "zeig mir Rechnung …",
+"Details zu dieser Rechnung", "was steht auf der Rechnung", "Positionen",
+"Line Items", "Skonto", "Fälligkeit". Für eine Liste mehrerer Rechnungen
+siehe `list_invoices`.
+
+| Parameter     | Type   | Required | Description                                                                   |
+|---------------|--------|----------|-------------------------------------------------------------------------------|
+| `document_id` | string | yes      | The UUID of the invoice's document (from `list_invoices` or `list_documents`) |
+
+### Payment Tools
+
+#### `list_money_accounts`
+
+Listet alle Bankkonten und Zahlungskonten des Mandanten: Bankkonten,
+Kreditkarten, PayPal, Wise, Kassa. Nutzen wenn der Benutzer nach
+"Bankkonto", "Bankkonten", "Konten", "Kreditkarte", "PayPal", "Kassa",
+"welche Konten haben wir", "IBAN" fragt — oder wenn eine Kontoauswahl für
+weitere Filter benötigt wird.
+
+**Parameters:** None
+
+#### `list_money_transactions`
+
+Listet Banktransaktionen und Kreditkartenbewegungen des Mandanten mit
+Betrag, Währung, Buchungsdatum, Valutadatum, Empfänger/Zahler,
+Verwendungszweck und Typ (EINGEHEND/AUSGEHEND). Filter: Konto, Typ,
+Datumsbereich, Partner-Name. Nutzen wenn der Benutzer nach "Transaktionen",
+"Banktransaktionen", "Buchungen auf dem Konto", "Kontoauszug", "Ein- und
+Ausgänge", "Zahlungseingang", "Zahlungsausgang", "Umsätze" fragt.
+
+| Parameter      | Type   | Required | Description                                                           |
+|----------------|--------|----------|-----------------------------------------------------------------------|
+| `limit`        | number | no       | Maximum number of transactions to return (default: 50, max: 1000)     |
+| `offset`       | number | no       | Number of transactions to skip for pagination (default: 0)            |
+| `account_id`   | string | no       | Filter to a specific money account (UUID from `list_money_accounts`)  |
+| `type`         | string | no       | Filter by direction: `INCOMING` (credit) or `OUTGOING` (debit)        |
+| `from_date`    | string | no       | Lower bound (inclusive) for the booking date (YYYY-MM-DD)             |
+| `until_date`   | string | no       | Upper bound (inclusive) for the booking date (YYYY-MM-DD)             |
+| `partner_name` | string | no       | Text filter on the counterparty name (case-insensitive partial match) |
+
+#### `get_invoice_payments`
+
+Liefert alle Zahlungen (Banktransaktionen), die einer bestimmten Rechnung
+zugeordnet sind, inkl. offenem Betrag, bereits verrechneter Summe,
+Zahlstatus und Zahldatum. Nutzen wenn der Benutzer nach "Zahlungen zur
+Rechnung", "ist bezahlt", "offener Betrag", "welche Zahlung wurde
+zugeordnet", "Zahlungsabgleich", "Payment Matching" für eine konkrete
+Rechnung fragt.
+
+| Parameter     | Type   | Required | Description                                                                   |
+|---------------|--------|----------|-------------------------------------------------------------------------------|
+| `document_id` | string | yes      | The UUID of the invoice's document (from `list_invoices` or `list_documents`) |
+
+### Company Tools
+
+#### `get_my_company`
+
+Liefert die Stammdaten des eigenen Mandanten (angemeldete Firma):
+Firmenname, Rechtsform, Hauptsitz/Adresse, Telefon, E-Mail, Website,
+UID/VAT-Nummer, Steuernummer, Handelsregister-Nummer. Nutzen wenn der
+Benutzer nach "meine Firma", "mein Mandant", "unsere Firma", "Firmendaten",
+"Stammdaten", "UID", "VAT-ID", "Steuernummer", "Firmenadresse", "Hauptsitz",
+"wer sind wir" fragt.
+
+**Parameters:** None
+
+#### `list_document_categories`
+
+Listet alle Dokumentenkategorien des Mandanten (visuelle Kategorien für
+die Ablage). Nutzen wenn der Benutzer nach "Kategorien",
+"Dokumentenkategorien", "Ablagekategorien", "welche Kategorien gibt es",
+"wo wird abgelegt" fragt oder bevor ein Dokument via `add_document`
+hochgeladen wird, um eine gültige `category_id` zu ermitteln.
+
+**Parameters:** None
+
+#### `list_gl_accounts`
+
+Listet alle Sachkonten (GL accounts, Hauptbuchkonten) des Mandanten mit
+Nummer und Bezeichnung. Nutzen wenn der Benutzer nach "Sachkonto",
+"Sachkonten", "Kontenplan", "Buchungskonto", "GL account", "general
+ledger", "Hauptbuch", "Kontonummer" fragt — typischerweise für
+Buchhaltung, Kontierung und Accounting-Export.
+
+**Parameters:** None
+
+#### `list_partner_companies`
+
+Listet Geschäftspartner des Mandanten: Kunden, Lieferanten, Debitoren,
+Kreditoren — mit Namen, abgeleitetem Namen, Debitoren- und
+Kreditoren-Kontonummer. Optional nach Namen filterbar. Nutzen wenn der
+Benutzer nach "Kunde", "Kunden", "Lieferant", "Lieferanten",
+"Geschäftspartner", "Partner", "Debitor", "Kreditor", "vendor",
+"supplier", "customer" fragt.
+
+| Parameter     | Type   | Required | Description                                                                                    |
+|---------------|--------|----------|------------------------------------------------------------------------------------------------|
+| `search_text` | string | no       | Optional text filter: partner companies whose name contains this substring (case-insensitive)  |
+| `limit`       | number | no       | Maximum number of results (default: 50, max: 1000)                                             |
+
+### User Tools
+
+#### `get_user`
+
+Liefert den aktuell angemeldeten Benutzer (Name, E-Mail, Sprache, Mandant).
+Nutzen wenn der Benutzer nach "wer bin ich", "mein Profil", "mein Konto",
+"Benutzer", "User", "angemeldet" fragt oder wenn ein anderes Tool die
+aktuelle Benutzer-ID benötigt. Funktioniert nur bei OAuth-Login —
+API-Key-Zugriff liefert hier einen Fehler, weil der Key einen Mandanten
+identifiziert, keinen Benutzer.
+
+**Parameters:** None
+
+### Workflow Tools
+
+#### `list_document_workflows`
+
+Listet alle im Mandanten konfigurierten Dokument-Workflows
+(Freigabe-Prozesse) mit Namen und IDs. Ein Workflow ist ein Ablauf, den
+ein Dokument durchläuft, bestehend aus mehreren Workflow-Schritten. Nutzen
+wenn der Benutzer nach "Workflows", "Freigabe-Prozess",
+"Genehmigungsprozess", "Approval-Flow", "welche Workflows gibt es" fragt.
+Für die einzelnen Schritte eines Workflows siehe
+`list_document_workflow_steps`.
+
+| Parameter | Type   | Required | Description                                                |
+|-----------|--------|----------|------------------------------------------------------------|
+| `limit`   | number | no       | Maximum number of rows to return (default: 100, max: 1000) |
+| `offset`  | number | no       | Number of rows to skip for pagination (default: 0)         |
+
+#### `list_document_workflow_steps`
+
+Listet Workflow-Schritte des Mandanten (einzelne Stationen eines
+Freigabe-Workflows). Ein Dokument steht zu jedem Zeitpunkt in genau einem
+Workflow-Schritt. Nutzen wenn der Benutzer nach "Workflow-Schritten",
+"Freigabeschritten", "Genehmigungsstufen", "welche Schritte hat unser
+Workflow", "Approval-Steps" fragt. Für den aktuellen Schritt konkreter
+Dokumente siehe `list_document_workflow_states`.
+
+| Parameter     | Type   | Required | Description                                                                                   |
+|---------------|--------|----------|-----------------------------------------------------------------------------------------------|
+| `workflow_id` | string | no       | Optional: UUID of a specific workflow to list only its steps (from `list_document_workflows`) |
+| `limit`       | number | no       | Maximum number of rows to return (default: 100, max: 1000)                                    |
+| `offset`      | number | no       | Number of rows to skip for pagination (default: 0)                                            |
+
+#### `list_document_workflow_states`
+
+Liefert den AKTUELLEN Workflow-Zustand von Dokumenten: in welchem
+Workflow-Schritt steht ein Dokument gerade, und wie lautet sein Status.
+Eine Zeile pro Dokument. Nutzen wenn der Benutzer nach "Wo steht das
+Dokument gerade", "in welchem Schritt", "Freigabestatus", "wartet auf
+Freigabe von …", "welche Dokumente hängen wo", "Workflow-Status" fragt.
+
+| Parameter     | Type   | Required | Description                                                            |
+|---------------|--------|----------|------------------------------------------------------------------------|
+| `document_id` | string | no       | Optional: UUID of a single document to return only its workflow state  |
+| `limit`       | number | no       | Maximum number of rows to return (default: 50, max: 1000)              |
+| `offset`      | number | no       | Number of rows to skip for pagination (default: 0)                     |
+
+### App URL Tools
+
+#### `get_app_urls`
+
+Liefert Deep-Links in die Domonda Web-App, zugeschnitten auf den
+angemeldeten Mandanten: Dokumente-Übersicht, Bank (Banking),
+Buchhaltungsansicht, Workflows/Freigaben, Academy (Hilfe/Doku),
+API-Repository. Nutzen wenn der Benutzer "öffne in Domonda", "zeig mir in
+der App", "Link zu …", "wo finde ich das", "geh in die Bank-Ansicht",
+"geh in die Buchhaltung" sagt.
+
+- `documents_overview` — main documents list
+- `banking` — banking overview
+- `accounting` — documents list with accounting view
+- `workflows` — documents list with workflow view (unapproved)
+- `documentation` — user-facing documentation (academy)
+- `api` — public API repository
+
+**Parameters:** None
+
+#### `get_document_urls`
+
+Liefert Deep-Links in die Domonda Web-App für EIN einzelnes Dokument: Tabs
+Prüfung (`review`), Zahlung (`payment`), Buchhaltung (`accounting`) und
+Zusammenarbeit (`collaboration`). Nutzen wenn der Benutzer "öffne dieses
+Dokument in Domonda", "Link zum Beleg", "spring zu
+Zahlung/Buchhaltung/Prüfung" für ein konkretes Dokument sagt. Das Dokument
+muss zum angemeldeten Mandanten gehören.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_selection_url`
+
+Liefert Deep-Links in die Domonda Web-App, die eine Auswahl MEHRERER
+Dokumente gemeinsam öffnen — je eine URL pro Mehrfach-Ansicht:
+`thumb_view` (Miniaturansicht), `list_view` (Listenansicht),
+`accounting_view` (Buchhaltungsansicht), `workflow_view` (Freigabenansicht).
+Nutzen wenn der Benutzer "öffne diese Rechnungen in Domonda", "zeig mir
+diese Belege in der App", "Link zu diesen Dokumenten",
+"Buchhaltungsansicht für diese Dokumente" sagt. Alle Dokumente müssen zum
+angemeldeten Mandanten gehören.
+
+URLs use the `?documentRowIds[]=<uuid>&view=<VIEW>` schema consumed by the
+domonda-app frontend routing; document ownership is verified per-id on the
+server.
+
+| Parameter      | Type            | Required | Description                                                              |
+|----------------|-----------------|----------|--------------------------------------------------------------------------|
+| `document_ids` | string[] (UUID) | yes      | List of document UUIDs to open together in the selection (at least one) |
+
+## Authentication
+
+The domonda MCP server uses JWT Bearer token authentication. The API key is a JWT where the `sub` claim contains the client company ID. All queries execute within a read-only, company-scoped database transaction.
+
+Pass the token in the HTTP `Authorization` header:
+
+```
+Authorization: Bearer <your-api-key>
+```
+
+## Usage Tips
+
+- Start with `get_my_company` to confirm connectivity and see which company you are authenticated as.
+- Use `list_tables` and `describe_table` for schema discovery before writing queries.
+- Use `execute_query` for ad-hoc SQL queries when the specialized tools don't cover your use case.
+- All date parameters use `YYYY-MM-DD` format.
+- UUID parameters must be valid UUID strings.
+- Results are capped at 1000 rows — use `limit` and `offset` for pagination.
+- `offset` is clamped to 100,000; stream beyond that by narrowing filters (date range, partner, status) instead of paginating deeper.
+- `execute_query` rejects SQL longer than 10,000 characters.

--- a/mcp/chatgpt/openai_responses_mcp.json.example
+++ b/mcp/chatgpt/openai_responses_mcp.json.example
@@ -1,0 +1,9 @@
+{
+  "type": "mcp",
+  "server_label": "domonda",
+  "server_url": "https://domonda.app/api/mcp/",
+  "headers": {
+    "Authorization": "Bearer ${DOMONDA_API_KEY}"
+  },
+  "require_approval": "never"
+}

--- a/mcp/chatgpt/scripts/health_check.sh
+++ b/mcp/chatgpt/scripts/health_check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source .env if present
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+# In production the domonda-web-server is mounted behind an /api path prefix,
+# so the MCP endpoint is https://domonda.app/api/mcp/. When running the web
+# server locally there is no /api prefix — use MCP_ENDPOINT to override, e.g.
+#   MCP_ENDPOINT=http://localhost:5001/mcp/ ./scripts/health_check.sh
+DOMONDA_URL="${DOMONDA_URL:-https://domonda.app}"
+MCP_ENDPOINT="${MCP_ENDPOINT:-${DOMONDA_URL}/api/mcp/}"
+
+if [ -z "${DOMONDA_API_KEY:-}" ]; then
+  echo "Error: DOMONDA_API_KEY is not set."
+  echo "Set it in your environment or in .env"
+  exit 1
+fi
+
+echo "Checking ${MCP_ENDPOINT} ..."
+
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer ${DOMONDA_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"health-check","version":"1.0.0"}}}' \
+  "${MCP_ENDPOINT}")
+
+if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+  echo "OK (HTTP ${HTTP_STATUS})"
+else
+  echo "FAILED (HTTP ${HTTP_STATUS})"
+  exit 1
+fi

--- a/mcp/claude-code/README.md
+++ b/mcp/claude-code/README.md
@@ -1,0 +1,248 @@
+# domonda MCP — Claude Code
+
+This directory contains setup instructions and configuration for connecting
+[**Claude Code**](https://claude.ai/claude-code) — Anthropic's CLI, Desktop,
+Web, and IDE-extension agent — to the [domonda](https://domonda.app) financial
+data platform via its
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server.
+
+Claude Code speaks Streamable HTTP MCP natively, so no `mcp-remote` bridge and
+no Node.js runtime are required. If you are configuring **Claude Desktop**,
+**Cowork**, or the **claude.ai web app**, use
+[`../claude-desktop/`](../claude-desktop/) instead — those surfaces share the
+Custom Connector UI (and fall back to `mcp-remote` for localhost).
+
+All query operations are **read-only**. The server exposes 28 tools covering
+documents, invoices, payments, money transactions, companies, GL accounts,
+partner companies, document workflows, web app deep links, ad-hoc SQL
+queries, and a `list_capabilities` discovery tool. The single write tool is
+`add_document`, which uploads a document via the same pipeline as the public
+upload endpoint.
+
+> **Live tool descriptions are in German.** The tool and parameter
+> descriptions surfaced by the running MCP server (and therefore what your
+> agent actually matches against user prompts) are written in German with
+> domain vocabulary pulled from the domonda-app UI (Sachkonto, Rechnung,
+> Gutschrift, Geschäftspartner, Fälligkeitsdatum, Mandant, Freigabe, …) and
+> a "Nutzen wenn …" trigger-phrase block for each tool. End users chat in
+> German, so the descriptions are optimised for the words they actually
+> use. Agents that are uncertain which tool to call should call
+> `list_capabilities` first for a topic-grouped catalog.
+
+## Prerequisites
+
+- [Claude Code](https://claude.ai/claude-code) installed (CLI, Desktop app,
+  Web app, or IDE extension — all share the same MCP config)
+- A domonda API key (JWT) — obtain from the domonda admin panel — or an
+  Auth0 OAuth access token for the MCP resource
+
+## Directory Structure
+
+```
+claude-code/
+├── SKILL.md              # Skill definition (frontmatter + tool reference)
+├── mcp.json.example      # Example project-scope .mcp.json
+├── scripts/
+│   └── health_check.sh   # Connectivity check script
+└── README.md             # This file
+```
+
+## Setup — pick one of three paths
+
+### 1. CLI (recommended, user scope, one-liner)
+
+Adds the server to your **user** config (`~/.claude.json`), available in every
+project you open with Claude Code:
+
+```bash
+claude mcp add --scope user --transport http domonda \
+  https://domonda.app/api/mcp/ \
+  --header "Authorization: Bearer $DOMONDA_API_KEY"
+```
+
+Verify it landed:
+
+```bash
+claude mcp list           # should show: domonda (http)
+```
+
+To remove it later: `claude mcp remove domonda`.
+
+### 2. Project scope (checked in, shared with teammates)
+
+Copy the example into the root of a repo and rename it to `.mcp.json`:
+
+```bash
+cp mcp/claude-code/mcp.json.example /path/to/your/project/.mcp.json
+```
+
+The example uses `${DOMONDA_API_KEY}` environment-variable expansion, which
+keeps the file safe to commit. Each teammate exports their own API key:
+
+```bash
+export DOMONDA_API_KEY=eyJhbGciOiJIUzI1NiIs...
+```
+
+Claude Code picks up `.mcp.json` automatically when opened at the repo root
+and prompts for trust on first load.
+
+### 3. Manual global config
+
+If you prefer editing config files directly, paste the `domonda` block into
+the top-level `mcpServers` key of `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "domonda": {
+      "type": "http",
+      "url": "https://domonda.app/api/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+This is exactly what `claude mcp add --scope user` writes for you. The bearer
+token is stored in **plaintext** in `~/.claude.json` — prefer path 1 (CLI) or
+path 2 (project `.mcp.json` with env expansion) when possible.
+
+### OAuth instead of an API key
+
+All three paths above assume a static JWT API key. If you'd rather sign in
+with your Auth0 account, **omit the `Authorization` header** — the domonda
+MCP server exposes RFC 9728 OAuth discovery metadata at
+`.well-known/oauth-protected-resource`, and Claude Code follows the
+`WWW-Authenticate` challenge to complete the flow in your browser on first
+use:
+
+```bash
+claude mcp add --scope user --transport http domonda \
+  https://domonda.app/api/mcp/
+```
+
+This avoids persisting a bearer token on disk and is the right choice for
+multi-company users who rely on the `X-Selected-Client-Company-ID` header.
+
+> Some Claude Code versions in the v2.1.85+ range have regressions in the
+> OAuth discovery flow
+> ([anthropics/claude-code#44830](https://github.com/anthropics/claude-code/issues/44830));
+> if OAuth gets stuck, fall back to the Bearer-token form above.
+
+### Base URL: production vs local
+
+In production the domonda-web-server is mounted behind an `/api` path prefix,
+so the MCP endpoint is `https://domonda.app/api/mcp/`. When running the web
+server locally there is **no** `/api` prefix — use `http://localhost:5001/mcp/`
+(5001 is the default port; override with `PORT=…`).
+
+## Verify Connectivity
+
+### Health check script
+
+```bash
+ export DOMONDA_API_KEY="your-api-key-here"   # leading space keeps this out of shell history
+./scripts/health_check.sh
+```
+
+Expected output:
+
+```
+Checking https://domonda.app/api/mcp/ ...
+OK (HTTP 200)
+```
+
+### Inside Claude Code
+
+Start a new Claude Code session and ask:
+
+> "Use the domonda tools to get company info."
+
+Claude should call `get_my_company` and return your company details.
+
+## Usage
+
+Once configured, Claude can call any of the 28 domonda tools.
+See `SKILL.md` for the complete tool reference with parameters.
+
+### Recommended first steps
+
+1. **`list_capabilities`** — When unsure which tool fits, get a grouped
+   catalog of all available tools first.
+2. **`get_my_company`** — Confirm authentication and see which company the
+   API key is scoped to.
+3. **`list_tables`** / **`describe_table`** — Explore the available database
+   schema before writing queries.
+4. **`list_documents`** or **`list_invoices`** — Browse recent data.
+5. **`execute_query`** — Run ad-hoc read-only SQL for anything the specialized
+   tools don't cover.
+
+### Tool categories
+
+| Category  | Tools                                                                                                                                                                      |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Discovery | `list_capabilities`                                                                                                                                                        |
+| Schema    | `list_tables`, `describe_table`                                                                                                                                            |
+| Query     | `execute_query`                                                                                                                                                            |
+| Documents | `list_documents`, `get_document`, `get_document_fulltext`, `search_documents`, `download_document_pdf`, `get_document_thumbnail`, `get_document_preview`, `add_document` (write) |
+| Invoices  | `list_invoices`, `get_invoice`                                                                                                                                             |
+| Payments  | `list_money_accounts`, `list_money_transactions`, `get_invoice_payments`                                                                                                   |
+| Company   | `get_my_company`, `list_document_categories`, `list_gl_accounts`, `list_partner_companies`                                                                                 |
+| User      | `get_user`                                                                                                                                                                 |
+| Workflows | `list_document_workflows`, `list_document_workflow_steps`, `list_document_workflow_states`                                                                                 |
+| App URLs  | `get_app_urls`, `get_document_urls`, `get_document_selection_url`                                                                                                          |
+
+### Example prompts
+
+- "Show me all invoices from January 2026 over 1,000"
+- "Download the PDF for document 8a2f..."
+- "Which GL accounts are in use?"
+- "Search documents for 'electricity bill'"
+- "Run a query to find the top 10 partners by invoice count"
+- "Upload this invoice PDF into the OTHER_DOCUMENTS category"
+
+## Authentication
+
+The domonda MCP server uses **Streamable HTTP** transport with **Bearer token**
+authentication. Two token types are supported:
+
+1. **API key (HS256 JWT)** — the standard domonda API key. The JWT `sub` claim
+   identifies the client company directly. This is the simplest option for
+   programmatic access.
+2. **OAuth (Auth0 RS256)** — an Auth0 access token issued for the MCP resource.
+   The token's Auth0 `sub` claim is mapped to a Domonda user, who must be
+   enabled and have access to the target company. Supports the
+   `X-Selected-Client-Company-ID` header for multi-company users. Clients that
+   support OAuth discovery will be guided automatically via the
+   `WWW-Authenticate` header and the `.well-known/oauth-protected-resource`
+   metadata endpoint (RFC 9728).
+
+```
+Authorization: Bearer <DOMONDA_API_KEY_OR_OAUTH_TOKEN>
+```
+
+The server enforces:
+
+- **Read-only transactions for query tools** — no INSERT, UPDATE, DELETE, or DDL
+- **Schema restriction** — only the `api` schema is accessible
+- **Row limit** — max 1,000 rows per query
+- **Query timeout** — 30-second default
+- **Query length** — max 10,000 characters
+- **Writes are limited to `add_document`** — processed through the same OCR,
+  duplicate-detection, and category-ownership checks as the public API
+
+## Troubleshooting
+
+| Symptom                                       | Cause                                                       | Fix                                                                                   |
+|-----------------------------------------------|-------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| `claude mcp list` doesn't show `domonda`      | Config not written, or written to a different scope         | Re-run the `claude mcp add` command and check `--scope`; inspect `~/.claude.json`     |
+| Tools don't appear in a Claude Code session   | Session started before the config was written               | Restart the Claude Code session / reload the window                                   |
+| `.mcp.json` not picked up                     | Session opened at the wrong working directory, or trust denied | Open Claude Code at the repo root; approve the trust prompt                        |
+| `${DOMONDA_API_KEY}` literally in requests    | Env var not exported in the shell that launched Claude Code | `export DOMONDA_API_KEY=…` before starting Claude Code                                |
+| HTTP 401                                      | Invalid, expired, or blocked token                          | Verify your API key or OAuth token; contact admin if blocked                          |
+| HTTP 403                                      | Forbidden company access or insufficient OAuth scopes       | Check the selected company or required scopes                                         |
+| HTTP 404                                      | Wrong endpoint URL                                          | Ensure the URL ends with `/mcp/` or `/mcp`                                            |
+| Query returns no rows                         | Company scoping — data belongs to another company           | Confirm `get_my_company` returns the expected company                                 |
+| `execute_query` rejected                      | SQL validation failed (DML, wrong schema)                   | Use only SELECT/WITH against the `api` schema                                         |

--- a/mcp/claude-code/SKILL.md
+++ b/mcp/claude-code/SKILL.md
@@ -1,0 +1,577 @@
+---
+name: domonda
+description: >
+  Use when you need to access domonda financial data — documents, invoices,
+  payments, money transactions, companies, GL accounts, partner companies,
+  and document workflows. Connects to the domonda MCP server via Streamable
+  HTTP with Bearer token authentication (API key or OAuth). All query tools
+  are read-only; the only write tool is `add_document`, which uploads a file
+  into the authenticated company's document pipeline.
+env:
+  - name: DOMONDA_API_KEY
+    required: true
+    secret: true
+    description: API key (HS256 JWT) or Auth0 OAuth access token for Bearer authentication
+  - name: DOMONDA_URL
+    required: false
+    secret: false
+    description: "Override domonda base URL (default: https://domonda.app)"
+---
+
+# domonda MCP Skill
+
+Connect to the [domonda](https://domonda.app) financial data platform via its MCP server.
+Query documents, invoices, payments, money transactions, companies, GL accounts, partner companies, and document workflows. All query tools are read-only; the only write tool is `add_document`, which uploads a file into the authenticated company's document pipeline.
+
+> **Language note.** The live MCP tool and parameter descriptions surfaced by
+> the server are written in **German**, including a "Nutzen wenn …" block of
+> trigger phrases. This matches the domonda-app UI and the natural vocabulary
+> of end users, and improves discoverability for clients (e.g. ChatGPT) that
+> match user prompts against tool descriptions by embedding similarity. The
+> English descriptions in this file are developer-facing reference only —
+> what your agent actually sees at runtime is the German text from the server.
+>
+> If you are unsure which tool to call, call `list_capabilities` first to get
+> a topic-grouped catalog of all available tools.
+
+## Agent Security Rules
+
+- **Never** display, log, or transmit the API key in plain text.
+- **Never** pass the API key as a CLI argument or embed it in URLs.
+- Only use the API key for authenticating against the domonda MCP endpoint.
+- Do not write, modify, or delete data via `execute_query` or any query tool — those tools are read-only and any DML will be rejected by the server.
+- The only write tool is `add_document`. Only call it when the user has explicitly asked you to upload a document. Never call it on your own initiative, and never use it to write arbitrary data.
+
+## Quick Start
+
+1. Get your domonda API key from the domonda admin panel.
+
+2. Register the server with Claude Code — pick one of:
+
+   **a. CLI (recommended, user scope):**
+
+   ```bash
+   claude mcp add --scope user --transport http domonda \
+     https://domonda.app/api/mcp/ \
+     --header "Authorization: Bearer $DOMONDA_API_KEY"
+   ```
+
+   **b. Project scope (`.mcp.json` at the repo root):**
+
+   ```json
+   {
+     "mcpServers": {
+       "domonda": {
+         "type": "http",
+         "url": "https://domonda.app/api/mcp/",
+         "headers": {
+           "Authorization": "Bearer ${DOMONDA_API_KEY}"
+         }
+       }
+     }
+   }
+   ```
+
+   Env-variable expansion (`${DOMONDA_API_KEY}`) is supported in `.mcp.json`,
+   so the file is safe to commit.
+
+   **c. OAuth instead of an API key:** omit the `Authorization` header — the
+   server advertises OAuth discovery (RFC 9728), and Claude Code will open an
+   Auth0 sign-in flow on first use.
+
+3. Start (or restart) your Claude Code session so it loads the new config.
+   Verify with `claude mcp list`.
+
+4. Run the health check to verify endpoint connectivity:
+
+   ```bash
+   ./scripts/health_check.sh
+   ```
+
+## Available Tools
+
+> The description paragraph for each tool below is written in **German**
+> (matching what the running MCP server actually surfaces to clients),
+> because domonda end users chat in German and tools are picked by
+> similarity to the user's prompt. The parameter tables and technical
+> notes stay in English.
+
+### Discovery
+
+#### `list_capabilities`
+
+Liefert einen nach Thema gruppierten Katalog ALLER verfügbaren Domonda-Tools
+mit einer kurzen deutschen Einzeiler-Beschreibung pro Tool. Dient als
+Einstiegspunkt: bei Unsicherheit, welches Tool passt, zuerst dieses
+aufrufen und dann das passende Tool direkt nutzen. Nutzen wenn der Benutzer
+nach "was kannst du", "welche Tools", "welche Werkzeuge", "hilf mir",
+"Übersicht", "Katalog", "was ist verfügbar", "Capabilities", "Hilfe" fragt.
+
+**Parameters:** None
+
+### Schema Tools
+
+#### `list_tables`
+
+Listet alle Tabellen und Views im `api`-Schema der Domonda-Datenbank (Name,
+Typ Tabelle/View, Beschreibung). Nutzen für Datenmodell-Exploration, bevor
+eine benutzerdefinierte Abfrage via `execute_query` gebaut wird, oder wenn
+der Benutzer nach "welche Tabellen gibt es", "Datenmodell", "Schema", "was
+ist in der DB" fragt.
+
+**Parameters:** None
+
+#### `describe_table`
+
+Beschreibt die Spalten einer Tabelle oder View im `api`-Schema:
+Spaltennamen, Datentypen, NULL-Zulässigkeit, Default-Werte. Nutzen bevor
+eine `SELECT`-Abfrage via `execute_query` geschrieben wird, um die
+verfügbaren Spalten zu kennen, oder wenn der Benutzer nach "welche
+Spalten", "Struktur der Tabelle", "Felder" fragt.
+
+| Parameter    | Type   | Required | Description                                                                                     |
+|------------- |--------|----------|-------------------------------------------------------------------------------------------------|
+| `table_name` | string | yes      | Name of the table or view in the `api` schema (e.g. `invoice`, `document`, `partner_company`)   |
+
+### Query Tools
+
+#### `execute_query`
+
+Führt eine READ-ONLY SQL-Abfrage (`SELECT` oder `WITH`) gegen das
+`api`-Schema der Domonda-Datenbank aus. Nur das `api`-Schema ist zugänglich;
+`pg_catalog`, `information_schema` und andere Schemata werden abgelehnt.
+Unqualifizierte Tabellennamen werden ins `api`-Schema aufgelöst. Ergebnis:
+JSON-Array von Objekten, maximal 1000 Zeilen. Daten sind automatisch auf
+den angemeldeten Mandanten eingeschränkt. Nutzen nur wenn die
+spezialisierten Tools (`list_documents`, `list_invoices`,
+`list_money_transactions`, …) nicht ausreichen und eine eigene Abfrage
+nötig ist. Vorher `list_tables` und `describe_table` nutzen, um das Schema
+zu erkunden.
+
+| Parameter | Type   | Required | Description                                                                                        |
+|-----------|--------|----------|----------------------------------------------------------------------------------------------------|
+| `sql`     | string | yes      | The SQL query to execute. Must start with `SELECT` or `WITH`. Only the `api` schema is accessible. |
+
+### Document Tools
+
+#### `list_documents`
+
+Sucht, filtert und listet Dokumente des Mandanten: Rechnungen, Verträge,
+Belege, Lieferscheine, Kontoauszüge, sonstige Dokumente, DMS. Unterstützt
+Volltextsuche, Datumsbereiche (mehrere Datumstypen), Beträge, Zahl- und
+Exportstatus, Geschäftspartner, Kategorien, Dokumentarten,
+Genehmigungsstatus, Duplikate, Kommentare, Vertragstypen und konfigurierbare
+Sortierung. Nutzen wenn der Benutzer nach "Dokumente", "Belege",
+"Rechnungen", "Verträge", "Lieferscheine", "Kontoauszüge", "Mahnungen",
+"was liegt im Eingang", "Dokumentenliste", "welche Dokumente gibt es zu …",
+"suche Beleg über …", "offene Rechnungen", "nicht freigegebene", "nicht
+exportierte" fragt. Für reine Volltextsuche ohne Filter siehe
+`search_documents`.
+
+All filter parameters are optional; omitting a parameter lets the server default apply.
+
+| Parameter                | Type            | Description                                                                                                               |
+|--------------------------|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| `limit`                  | number          | Maximum number of documents to return (default 50, max 1000)                                                              |
+| `offset`                 | number          | Number of documents to skip for pagination                                                                                |
+| `search_text`            | string          | Fulltext search over the extracted document content (OCR + structured data)                                               |
+| `archived`               | string enum     | `exclude` (default, only active), `only` (only archived), or `include` (both)                                             |
+| `has_warning`            | boolean         | `true`: only documents with a warning; `false`: only documents without                                                    |
+| `internal_number`        | string          | Filter by domonda-internal sequential document number                                                                     |
+| `date_filter_type`       | string enum     | Which date `from_date`/`until_date` apply to: `DOCUMENT_DATE`, `INVOICE_DATE` (default), `IMPORT_DATE`, `DUE_DATE`, `DISCOUNT_DUE_DATE`, `PAID_DATE`, `DELIVERED_DATE` |
+| `from_date`              | string          | Lower bound (inclusive) for the date selected via `date_filter_type` (YYYY-MM-DD)                                         |
+| `until_date`             | string          | Upper bound (inclusive) for the date selected via `date_filter_type` (YYYY-MM-DD)                                         |
+| `min_total`              | number          | Only documents with invoice gross total ≥ this amount                                                                     |
+| `max_total`              | number          | Only documents with invoice gross total ≤ this amount                                                                     |
+| `export_status`          | string enum     | Accounting export status (exported / not exported, for "booking" or "ready for booking"; see tool schema for the full enum) |
+| `paid_status`            | string enum     | Invoice payment status: paid, partially paid, not paid, not payable, or paid via a specific payment method                 |
+| `document_types`         | string[] enum   | One or more document types (incoming/outgoing invoice, dunning letter, delivery note, bank/credit-card statement, other document, DMS, …) |
+| `document_category_ids`  | string[] (UUID) | One or more document category IDs (from `list_document_categories`)                                                        |
+| `partner_company_ids`    | string[] (UUID) | One or more partner company IDs (customer or supplier, from `list_partner_companies`)                                      |
+| `is_credit_memo`         | boolean         | `true`: only credit memos (Gutschriften); `false`: exclude credit memos                                                    |
+| `has_pain001_payment`    | boolean         | `true`: only documents with a generated SEPA credit transfer (PAIN.001); `false`: without                                  |
+| `has_pain008_direct_debit` | boolean       | `true`: only documents with a generated SEPA direct debit (PAIN.008); `false`: without                                     |
+| `is_payment_reminder_sent` | boolean       | `true`: only documents for which a payment reminder/dunning letter has already been sent                                   |
+| `is_approved`            | boolean         | `true`: only approved documents; `false`: only not-yet-approved documents (waiting for workflow approval)                  |
+| `is_duplicate`           | boolean         | `true`: only documents detected as duplicates; `false`: only non-duplicates                                                |
+| `has_comments`           | boolean         | `true`: only documents with comments; `false`: without                                                                     |
+| `is_recurring`           | boolean         | `true`: only recurring documents; `false`: only one-off documents                                                          |
+| `contract_type`          | string enum     | Contract type filter for `OTHER_DOCUMENT`s (service contracts, rental contracts, insurance, …; see tool schema)            |
+| `order_bys`              | string[] enum   | Ordering rules applied in sequence; default `IMPORT_DATE_DESC` (most recently imported first)                              |
+
+> The full enum values for `export_status`, `paid_status`, `document_types`, `contract_type`, and `order_bys` are exposed on the live tool schema — your MCP client will surface them.
+
+#### `get_document`
+
+Liefert Metadaten eines einzelnen Dokuments anhand seiner UUID: Dokumentart,
+Kategorie, Geschäftspartner, Datum, Status, Beträge (soweit vorhanden).
+Enthält **nicht** den Volltext — siehe `get_document_fulltext` für den
+extrahierten OCR-Text oder `get_invoice` für Rechnungs-Positionen. Nutzen
+wenn der Benutzer nach "Details zum Dokument", "Info zu diesem Beleg", "was
+ist das für ein Dokument", "wer hat das hochgeladen", "welche Kategorie"
+fragt.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_fulltext`
+
+Liefert den extrahierten Volltext (OCR) eines Dokuments. Nutzen wenn der
+Benutzer den kompletten Inhalt eines Dokuments lesen will — "Volltext",
+"was steht im Beleg", "OCR-Text", "Inhalt dieses Dokuments".
+
+**Warning:** fulltexts can be very large; long documents may approach or
+exceed the MCP response byte cap (default 10 MiB)
+and the call will fail. For pure search prefer `search_documents` and only
+fetch the fulltext of a specific hit when really needed.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `search_documents`
+
+Volltextsuche über alle Dokumente des Mandanten; Treffer sind nach Relevanz
+sortiert. Nutzen wenn der Benutzer etwas FINDEN will, statt gezielt zu
+filtern — z. B. "finde Beleg über Büromöbel", "such mir alles zu Projekt
+X", "gibt es eine Rechnung mit …", "wo taucht der Begriff … auf". Für
+strukturierte Filter (Datum, Partner, Status, Beträge) lieber
+`list_documents` verwenden.
+
+| Parameter | Type   | Required | Description                                          |
+|-----------|--------|----------|------------------------------------------------------|
+| `query`   | string | yes      | Search term or phrase for the fulltext search        |
+| `limit`   | number | no       | Maximum number of results (default: 20, max: 1000)   |
+
+#### `download_document_pdf`
+
+Lädt die Original-PDF-Datei eines Dokuments herunter — optional mit
+angehängtem oder vorangestelltem Audit-Trail (Protokoll der
+Bearbeitungsschritte, Freigaben, Änderungen). Standard: die PDF-Bytes
+werden base64-kodiert inline zurückgegeben. Mit `inline: false` wird
+stattdessen ein MCP `resource_link` auf `document://{document_id}/pdf?...`
+geliefert, den ein resource-fähiger Client via `resources/read` nachladen
+kann. Nutzen wenn der Benutzer "die PDF", "das Original", "den Beleg
+herunterladen", "Rechnung als PDF", "mit Audit-Trail" sagt.
+
+| Parameter          | Type    | Required | Description                                                                        |
+|--------------------|---------|----------|------------------------------------------------------------------------------------|
+| `document_id`      | string  | yes      | The UUID of the document                                                           |
+| `audit_trail`      | string  | no       | Audit-trail position in the PDF: `append`, `prepend`, `configured` (mandant setting), or `only` (audit trail only). Empty = no audit trail. |
+| `audit_trail_lang` | string  | no       | Language of the audit trail as ISO 639-1 code (default `de`)                       |
+| `inline`           | boolean | no       | `true` (default): return the PDF bytes inline as a base64-encoded resource. `false`: return an MCP `resource_link` to `document://{document_id}/pdf?...` that a resource-aware client loads via `resources/read`. |
+
+The PDF is also exposed as an MCP resource at `document://{document_id}/pdf{?audit_trail,audit_trail_lang}`, so resource-aware clients can fetch it via `resources/read`. The `configured` audit-trail value is resolved to `append`/`prepend` before a resource link is returned, so resource URIs are deterministic and cacheable.
+
+#### `get_document_thumbnail`
+
+Liefert die kleine Miniaturansicht (JPEG, 256 px breit, Seitenverhältnis
+erhalten) eines Dokuments als base64-kodierten Blob. Auch als MCP-Ressource
+unter `document://{document_id}/thumb_256x0.jpeg` verfügbar. Nutzen wenn
+der Benutzer eine schnelle Vorschau, ein Miniaturbild oder ein "Icon" eines
+Dokuments sehen will. Für eine größere Vorschau siehe `get_document_preview`.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_preview`
+
+Liefert die große Vorschau (JPEG, 964×1364) eines Dokuments als
+base64-kodierten Blob — das größte vorgerenderte Vorschaubild. Auch als
+MCP-Ressource unter `document://{document_id}/preview.jpeg` verfügbar.
+Nutzen wenn der Benutzer "zeig mir das Dokument", "Vorschau", "wie sieht
+der Beleg aus", "Bild des Dokuments" sagt. Für eine kleinere Miniaturansicht
+siehe `get_document_thumbnail`; für die Original-PDF siehe
+`download_document_pdf`.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `add_document` (write)
+
+Lädt ein neues Dokument (Rechnung, Beleg, Vertrag, Lieferschein, sonstige
+Datei) für den angemeldeten Mandanten hoch. Dubletten-Erkennung und
+Kategorie-Zuweisung laufen automatisch. Nutzen wenn der Benutzer "Dokument
+hochladen", "Beleg importieren", "Rechnung hinzufügen", "upload", "neues
+Dokument", "Datei einspielen" sagt. Vorher `list_document_categories`
+aufrufen, um eine gültige `category_id` zu ermitteln.
+
+Supported file types: PDF, PNG, JPEG, TIFF, XML, HTML, RTF, DOC, DOCX, ODT,
+XLS, XLSX, ODS. This is the **only write operation** on the MCP server; the
+file is processed through the same pipeline as the public upload endpoint.
+Returns the new document UUID on success.
+
+| Parameter                 | Type    | Required | Description                                                                                |
+|---------------------------|---------|----------|--------------------------------------------------------------------------------------------|
+| `file_data`               | string  | yes      | Base64-encoded file content (no URL, no path — the raw bytes base64-encoded)                |
+| `filename`                | string  | yes      | Original filename including extension (e.g. `invoice_2026_04.pdf`)                         |
+| `category_id`             | string  | yes      | Document category UUID (use `list_document_categories` to find valid IDs)                  |
+| `tags`                    | string[]| no       | Optional document tags                                                                     |
+| `allow_duplicate_deleted` | boolean | no       | If `true`, allow re-uploading a file whose hash matches a previously-deleted document. Default `false`. |
+| `wait_for_extraction`     | boolean | no       | If `true`, wait synchronously for OCR/extraction before returning. Default `false` (asynchronous). |
+
+> **Agent guidance:** Only call `add_document` when the user has explicitly asked you to upload a file. Do not use it on your own initiative.
+
+### Invoice Tools
+
+#### `list_invoices`
+
+Listet Rechnungen des Mandanten (Eingangs- und Ausgangsrechnungen, inkl.
+Gutschriften) mit Rechnungsnummer, Rechnungsdatum, Fälligkeitsdatum,
+Geschäftspartner, Netto, Brutto, Währung, USt-Satz, Zahlstatus, offenem
+Betrag und Buchungsstatus. Filter: Datumsbereich, Partner-Name,
+Mindest-/Maximalbetrag. Nutzen wenn der Benutzer nach "Rechnungen",
+"Eingangsrechnungen", "Ausgangsrechnungen", "ER", "AR", "Gutschriften",
+"offene Posten", "Forderungen", "Verbindlichkeiten", "unbezahlte
+Rechnungen", "Rechnungen von <Firma>" fragt. Für einzelne Rechnungsdetails
+siehe `get_invoice`.
+
+| Parameter      | Type   | Required | Description                                                                                                  |
+|----------------|--------|----------|--------------------------------------------------------------------------------------------------------------|
+| `limit`        | number | no       | Maximum number of invoices to return (default: 50, max: 1000)                                                |
+| `offset`       | number | no       | Number of invoices to skip for pagination (default: 0)                                                       |
+| `from_date`    | string | no       | Lower bound (inclusive) for the invoice date (YYYY-MM-DD)                                                    |
+| `until_date`   | string | no       | Upper bound (inclusive) for the invoice date (YYYY-MM-DD)                                                    |
+| `partner_name` | string | no       | Filter by partner company name (customer or supplier, case-insensitive partial match)                        |
+| `min_total`    | number | no       | Only invoices with gross total ≥ this amount                                                                 |
+| `max_total`    | number | no       | Only invoices with gross total ≤ this amount                                                                 |
+
+#### `get_invoice`
+
+Liefert alle Details zu einer einzelnen Rechnung: Kopfdaten, Positionen
+(Line Items), Skonto, Fälligkeit, umgerechnete EUR-Beträge, Geschäftspartner,
+UID/VAT-ID des Partners, zugeordnete Zahlungen. Nutzen wenn der Benutzer
+eine konkrete Rechnung im Detail sehen will — "zeig mir Rechnung …",
+"Details zu dieser Rechnung", "was steht auf der Rechnung", "Positionen",
+"Line Items", "Skonto", "Fälligkeit". Für eine Liste mehrerer Rechnungen
+siehe `list_invoices`.
+
+| Parameter     | Type   | Required | Description                                                                   |
+|---------------|--------|----------|-------------------------------------------------------------------------------|
+| `document_id` | string | yes      | The UUID of the invoice's document (from `list_invoices` or `list_documents`) |
+
+### Payment Tools
+
+#### `list_money_accounts`
+
+Listet alle Bankkonten und Zahlungskonten des Mandanten: Bankkonten,
+Kreditkarten, PayPal, Wise, Kassa. Nutzen wenn der Benutzer nach
+"Bankkonto", "Bankkonten", "Konten", "Kreditkarte", "PayPal", "Kassa",
+"welche Konten haben wir", "IBAN" fragt — oder wenn eine Kontoauswahl für
+weitere Filter benötigt wird.
+
+**Parameters:** None
+
+#### `list_money_transactions`
+
+Listet Banktransaktionen und Kreditkartenbewegungen des Mandanten mit
+Betrag, Währung, Buchungsdatum, Valutadatum, Empfänger/Zahler,
+Verwendungszweck und Typ (EINGEHEND/AUSGEHEND). Filter: Konto, Typ,
+Datumsbereich, Partner-Name. Nutzen wenn der Benutzer nach "Transaktionen",
+"Banktransaktionen", "Buchungen auf dem Konto", "Kontoauszug", "Ein- und
+Ausgänge", "Zahlungseingang", "Zahlungsausgang", "Umsätze" fragt.
+
+| Parameter      | Type   | Required | Description                                                           |
+|----------------|--------|----------|-----------------------------------------------------------------------|
+| `limit`        | number | no       | Maximum number of transactions to return (default: 50, max: 1000)     |
+| `offset`       | number | no       | Number of transactions to skip for pagination (default: 0)            |
+| `account_id`   | string | no       | Filter to a specific money account (UUID from `list_money_accounts`)  |
+| `type`         | string | no       | Filter by direction: `INCOMING` (credit) or `OUTGOING` (debit)        |
+| `from_date`    | string | no       | Lower bound (inclusive) for the booking date (YYYY-MM-DD)             |
+| `until_date`   | string | no       | Upper bound (inclusive) for the booking date (YYYY-MM-DD)             |
+| `partner_name` | string | no       | Text filter on the counterparty name (case-insensitive partial match) |
+
+#### `get_invoice_payments`
+
+Liefert alle Zahlungen (Banktransaktionen), die einer bestimmten Rechnung
+zugeordnet sind, inkl. offenem Betrag, bereits verrechneter Summe,
+Zahlstatus und Zahldatum. Nutzen wenn der Benutzer nach "Zahlungen zur
+Rechnung", "ist bezahlt", "offener Betrag", "welche Zahlung wurde
+zugeordnet", "Zahlungsabgleich", "Payment Matching" für eine konkrete
+Rechnung fragt.
+
+| Parameter     | Type   | Required | Description                                                                   |
+|---------------|--------|----------|-------------------------------------------------------------------------------|
+| `document_id` | string | yes      | The UUID of the invoice's document (from `list_invoices` or `list_documents`) |
+
+### Company Tools
+
+#### `get_my_company`
+
+Liefert die Stammdaten des eigenen Mandanten (angemeldete Firma):
+Firmenname, Rechtsform, Hauptsitz/Adresse, Telefon, E-Mail, Website,
+UID/VAT-Nummer, Steuernummer, Handelsregister-Nummer. Nutzen wenn der
+Benutzer nach "meine Firma", "mein Mandant", "unsere Firma", "Firmendaten",
+"Stammdaten", "UID", "VAT-ID", "Steuernummer", "Firmenadresse", "Hauptsitz",
+"wer sind wir" fragt.
+
+**Parameters:** None
+
+#### `list_document_categories`
+
+Listet alle Dokumentenkategorien des Mandanten (visuelle Kategorien für
+die Ablage). Nutzen wenn der Benutzer nach "Kategorien",
+"Dokumentenkategorien", "Ablagekategorien", "welche Kategorien gibt es",
+"wo wird abgelegt" fragt oder bevor ein Dokument via `add_document`
+hochgeladen wird, um eine gültige `category_id` zu ermitteln.
+
+**Parameters:** None
+
+#### `list_gl_accounts`
+
+Listet alle Sachkonten (GL accounts, Hauptbuchkonten) des Mandanten mit
+Nummer und Bezeichnung. Nutzen wenn der Benutzer nach "Sachkonto",
+"Sachkonten", "Kontenplan", "Buchungskonto", "GL account", "general
+ledger", "Hauptbuch", "Kontonummer" fragt — typischerweise für
+Buchhaltung, Kontierung und Accounting-Export.
+
+**Parameters:** None
+
+#### `list_partner_companies`
+
+Listet Geschäftspartner des Mandanten: Kunden, Lieferanten, Debitoren,
+Kreditoren — mit Namen, abgeleitetem Namen, Debitoren- und
+Kreditoren-Kontonummer. Optional nach Namen filterbar. Nutzen wenn der
+Benutzer nach "Kunde", "Kunden", "Lieferant", "Lieferanten",
+"Geschäftspartner", "Partner", "Debitor", "Kreditor", "vendor",
+"supplier", "customer" fragt.
+
+| Parameter     | Type   | Required | Description                                                                                    |
+|---------------|--------|----------|------------------------------------------------------------------------------------------------|
+| `search_text` | string | no       | Optional text filter: partner companies whose name contains this substring (case-insensitive)  |
+| `limit`       | number | no       | Maximum number of results (default: 50, max: 1000)                                             |
+
+### User Tools
+
+#### `get_user`
+
+Liefert den aktuell angemeldeten Benutzer (Name, E-Mail, Sprache, Mandant).
+Nutzen wenn der Benutzer nach "wer bin ich", "mein Profil", "mein Konto",
+"Benutzer", "User", "angemeldet" fragt oder wenn ein anderes Tool die
+aktuelle Benutzer-ID benötigt. Funktioniert nur bei OAuth-Login —
+API-Key-Zugriff liefert hier einen Fehler, weil der Key einen Mandanten
+identifiziert, keinen Benutzer.
+
+**Parameters:** None
+
+### Workflow Tools
+
+#### `list_document_workflows`
+
+Listet alle im Mandanten konfigurierten Dokument-Workflows
+(Freigabe-Prozesse) mit Namen und IDs. Ein Workflow ist ein Ablauf, den
+ein Dokument durchläuft, bestehend aus mehreren Workflow-Schritten. Nutzen
+wenn der Benutzer nach "Workflows", "Freigabe-Prozess",
+"Genehmigungsprozess", "Approval-Flow", "welche Workflows gibt es" fragt.
+Für die einzelnen Schritte eines Workflows siehe
+`list_document_workflow_steps`.
+
+| Parameter | Type   | Required | Description                                                |
+|-----------|--------|----------|------------------------------------------------------------|
+| `limit`   | number | no       | Maximum number of rows to return (default: 100, max: 1000) |
+| `offset`  | number | no       | Number of rows to skip for pagination (default: 0)         |
+
+#### `list_document_workflow_steps`
+
+Listet Workflow-Schritte des Mandanten (einzelne Stationen eines
+Freigabe-Workflows). Ein Dokument steht zu jedem Zeitpunkt in genau einem
+Workflow-Schritt. Nutzen wenn der Benutzer nach "Workflow-Schritten",
+"Freigabeschritten", "Genehmigungsstufen", "welche Schritte hat unser
+Workflow", "Approval-Steps" fragt. Für den aktuellen Schritt konkreter
+Dokumente siehe `list_document_workflow_states`.
+
+| Parameter     | Type   | Required | Description                                                                                   |
+|---------------|--------|----------|-----------------------------------------------------------------------------------------------|
+| `workflow_id` | string | no       | Optional: UUID of a specific workflow to list only its steps (from `list_document_workflows`) |
+| `limit`       | number | no       | Maximum number of rows to return (default: 100, max: 1000)                                    |
+| `offset`      | number | no       | Number of rows to skip for pagination (default: 0)                                            |
+
+#### `list_document_workflow_states`
+
+Liefert den AKTUELLEN Workflow-Zustand von Dokumenten: in welchem
+Workflow-Schritt steht ein Dokument gerade, und wie lautet sein Status.
+Eine Zeile pro Dokument. Nutzen wenn der Benutzer nach "Wo steht das
+Dokument gerade", "in welchem Schritt", "Freigabestatus", "wartet auf
+Freigabe von …", "welche Dokumente hängen wo", "Workflow-Status" fragt.
+
+| Parameter     | Type   | Required | Description                                                            |
+|---------------|--------|----------|------------------------------------------------------------------------|
+| `document_id` | string | no       | Optional: UUID of a single document to return only its workflow state  |
+| `limit`       | number | no       | Maximum number of rows to return (default: 50, max: 1000)              |
+| `offset`      | number | no       | Number of rows to skip for pagination (default: 0)                     |
+
+### App URL Tools
+
+#### `get_app_urls`
+
+Liefert Deep-Links in die Domonda Web-App, zugeschnitten auf den
+angemeldeten Mandanten: Dokumente-Übersicht, Bank (Banking),
+Buchhaltungsansicht, Workflows/Freigaben, Academy (Hilfe/Doku),
+API-Repository. Nutzen wenn der Benutzer "öffne in Domonda", "zeig mir in
+der App", "Link zu …", "wo finde ich das", "geh in die Bank-Ansicht",
+"geh in die Buchhaltung" sagt.
+
+- `documents_overview` — main documents list
+- `banking` — banking overview
+- `accounting` — documents list with accounting view
+- `workflows` — documents list with workflow view (unapproved)
+- `documentation` — user-facing documentation (academy)
+- `api` — public API repository
+
+**Parameters:** None
+
+#### `get_document_urls`
+
+Liefert Deep-Links in die Domonda Web-App für EIN einzelnes Dokument: Tabs
+Prüfung (`review`), Zahlung (`payment`), Buchhaltung (`accounting`) und
+Zusammenarbeit (`collaboration`). Nutzen wenn der Benutzer "öffne dieses
+Dokument in Domonda", "Link zum Beleg", "spring zu
+Zahlung/Buchhaltung/Prüfung" für ein konkretes Dokument sagt. Das Dokument
+muss zum angemeldeten Mandanten gehören.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_selection_url`
+
+Liefert Deep-Links in die Domonda Web-App, die eine Auswahl MEHRERER
+Dokumente gemeinsam öffnen — je eine URL pro Mehrfach-Ansicht:
+`thumb_view` (Miniaturansicht), `list_view` (Listenansicht),
+`accounting_view` (Buchhaltungsansicht), `workflow_view` (Freigabenansicht).
+Nutzen wenn der Benutzer "öffne diese Rechnungen in Domonda", "zeig mir
+diese Belege in der App", "Link zu diesen Dokumenten",
+"Buchhaltungsansicht für diese Dokumente" sagt. Alle Dokumente müssen zum
+angemeldeten Mandanten gehören.
+
+URLs use the `?documentRowIds[]=<uuid>&view=<VIEW>` schema consumed by the
+domonda-app frontend routing; document ownership is verified per-id on the
+server.
+
+| Parameter      | Type            | Required | Description                                                              |
+|----------------|-----------------|----------|--------------------------------------------------------------------------|
+| `document_ids` | string[] (UUID) | yes      | List of document UUIDs to open together in the selection (at least one) |
+
+## Authentication
+
+The domonda MCP server uses JWT Bearer token authentication. The API key is a JWT where the `sub` claim contains the client company ID. All queries execute within a read-only, company-scoped database transaction.
+
+Pass the token in the HTTP `Authorization` header:
+
+```
+Authorization: Bearer <your-api-key>
+```
+
+## Usage Tips
+
+- Start with `get_my_company` to confirm connectivity and see which company you are authenticated as.
+- Use `list_tables` and `describe_table` for schema discovery before writing queries.
+- Use `execute_query` for ad-hoc SQL queries when the specialized tools don't cover your use case.
+- All date parameters use `YYYY-MM-DD` format.
+- UUID parameters must be valid UUID strings.
+- Results are capped at 1000 rows — use `limit` and `offset` for pagination.
+- `offset` is clamped to 100,000; stream beyond that by narrowing filters (date range, partner, status) instead of paginating deeper.
+- `execute_query` rejects SQL longer than 10,000 characters.

--- a/mcp/claude-code/mcp.json.example
+++ b/mcp/claude-code/mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "domonda": {
+      "type": "http",
+      "url": "https://domonda.app/api/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${DOMONDA_API_KEY}"
+      }
+    }
+  }
+}

--- a/mcp/claude-code/scripts/health_check.sh
+++ b/mcp/claude-code/scripts/health_check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source .env if present
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+# In production the domonda-web-server is mounted behind an /api path prefix,
+# so the MCP endpoint is https://domonda.app/api/mcp/. When running the web
+# server locally there is no /api prefix — use MCP_ENDPOINT to override, e.g.
+#   MCP_ENDPOINT=http://localhost:5001/mcp/ ./scripts/health_check.sh
+DOMONDA_URL="${DOMONDA_URL:-https://domonda.app}"
+MCP_ENDPOINT="${MCP_ENDPOINT:-${DOMONDA_URL}/api/mcp/}"
+
+if [ -z "${DOMONDA_API_KEY:-}" ]; then
+  echo "Error: DOMONDA_API_KEY is not set."
+  echo "Set it in your environment or in .env"
+  exit 1
+fi
+
+echo "Checking ${MCP_ENDPOINT} ..."
+
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer ${DOMONDA_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"health-check","version":"1.0.0"}}}' \
+  "${MCP_ENDPOINT}")
+
+if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+  echo "OK (HTTP ${HTTP_STATUS})"
+else
+  echo "FAILED (HTTP ${HTTP_STATUS})"
+  exit 1
+fi

--- a/mcp/claude-desktop/README.md
+++ b/mcp/claude-desktop/README.md
@@ -1,0 +1,330 @@
+# domonda MCP — Claude Desktop & Cowork
+
+This directory contains setup instructions and configuration for connecting
+**Claude Desktop**, [**Claude Cowork**](https://claude.com/product/cowork),
+and the **claude.ai web app** to the [domonda](https://domonda.app) financial
+data platform via its
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server. All
+three surfaces share the same Custom Connector UI.
+
+All query operations are **read-only**. The server exposes 28 tools covering
+documents, invoices, payments, money transactions, companies, GL accounts,
+partner companies, document workflows, web app deep links, ad-hoc SQL
+queries, and a `list_capabilities` discovery tool. The single write tool is
+`add_document`, which uploads a document via the same pipeline as the public
+upload endpoint.
+
+> **Live tool descriptions are in German.** The tool and parameter
+> descriptions surfaced by the running MCP server (and therefore what your
+> agent actually matches against user prompts) are written in German with
+> domain vocabulary pulled from the domonda-app UI (Sachkonto, Rechnung,
+> Gutschrift, Geschäftspartner, Fälligkeitsdatum, Mandant, Freigabe, …) and
+> a "Nutzen wenn …" trigger-phrase block for each tool. End users chat in
+> German, so the descriptions are optimised for the words they actually
+> use. Agents that are uncertain which tool to call should call
+> `list_capabilities` first for a topic-grouped catalog.
+
+## Prerequisites
+
+- **Claude Desktop** app ([download](https://claude.ai/download)),
+  [**Cowork**](https://claude.com/product/cowork), or a paid plan on
+  [claude.ai](https://claude.ai/) (Free plan is limited to one custom
+  connector)
+- A domonda API key (JWT) — obtain from the domonda admin panel — or an
+  Auth0 OAuth access token for the MCP resource
+- **For the stdio-bridge fallback only:** Node.js and `npx` (see the
+  [What is `npx`?](#what-is-npx) section below for how to install them)
+
+## Directory Structure
+
+```
+claude-desktop/
+├── SKILL.md                              # Skill definition (frontmatter + tool reference)
+├── claude_desktop_config.json.example    # Example Claude Desktop configuration
+├── scripts/
+│   └── health_check.sh                  # Connectivity check script
+└── README.md                            # This file
+```
+
+## Claude Desktop Setup
+
+Claude Desktop supports two paths. Use the **Custom Connector UI** for
+production; use the **`mcp-remote` stdio bridge** only when the UI path can't
+reach your endpoint (localhost) or when you need to inject a raw Bearer JWT
+without an OAuth flow.
+
+### Option 1 — Custom Connector UI (recommended)
+
+Available on Free, Pro, Max, Team, and Enterprise plans (Free is limited to
+one custom connector). Anthropic's cloud dials the MCP endpoint on your
+behalf — your machine does not need Node.js, and there is no config file to
+edit.
+
+1. Open **Settings → Connectors** (inside Claude Desktop or at
+   [claude.ai](https://claude.ai/) → Settings → Connectors).
+2. Scroll to **Add custom connector**.
+3. Enter the MCP URL: `https://domonda.app/api/mcp/`
+4. Complete the authentication prompt. domonda's MCP endpoint serves the
+   Auth0 OAuth discovery metadata (`.well-known/oauth-protected-resource`
+   per RFC 9728), so the UI will redirect you to Auth0 to sign in.
+5. Confirm the tools appear in the tool picker (hammer icon) in a new chat.
+
+> **Doesn't work for localhost.** The connector originates from Anthropic's
+> cloud, not your machine, so `http://localhost:5001/mcp/` is unreachable.
+> Use Option 2 for local development.
+>
+> **Plain API-key JWTs aren't supported here.** The UI drives an OAuth flow;
+> use Option 2 if you want to paste a raw `Authorization: Bearer <jwt>`
+> header instead.
+
+### Option 2 — `mcp-remote` stdio bridge (fallback)
+
+Use this when the Custom Connector UI doesn't fit: **localhost dev endpoints**
+or **raw Bearer JWT** authentication without OAuth. Claude Desktop talks
+stdio to the local `mcp-remote` process, which in turn speaks Streamable
+HTTP to the domonda server.
+
+See [mcp-remote](https://www.npmjs.com/package/mcp-remote) for the upstream
+package.
+
+#### What is `npx`?
+
+`npx` is a small command that ships with [Node.js](https://nodejs.org/) — the
+JavaScript runtime that powers tools like VS Code, Slack's desktop app, and
+countless developer utilities. When Claude Desktop's config says
+`"command": "npx"`, it is asking your computer to run a JavaScript program
+(in this case `mcp-remote`, the little bridge that lets Claude Desktop reach
+a web-based MCP server). `npx` downloads that program on demand the first
+time you use it and caches it for later runs — no separate installation
+step, no app in your Applications folder.
+
+To install Node.js (which also gives you `npx`):
+
+- **macOS / Linux:** download the LTS installer from
+  [nodejs.org](https://nodejs.org/) and run it, or use a package manager
+  like [Homebrew](https://brew.sh/) (`brew install node`) or `apt install
+  nodejs npm`.
+- **Windows:** download the LTS installer from
+  [nodejs.org](https://nodejs.org/) and run it. The installer adds `node`
+  and `npx` to your `PATH` automatically, so Claude Desktop can find them.
+
+Verify after install: open a new terminal and run `npx --version`. You
+should see something like `10.x.x`. If you see "command not found," restart
+your terminal (or sign out and back in on Windows) so the updated `PATH`
+takes effect.
+
+> If installing Node.js on the end-user's machine isn't realistic, prefer
+> Option 1 (Custom Connector UI) — it requires no local runtime at all.
+
+#### 1. Locate the configuration file
+
+| Platform | Path                                                                 |
+|----------|----------------------------------------------------------------------|
+| macOS    | `~/Library/Application Support/Claude/claude_desktop_config.json`    |
+| Windows  | `%APPDATA%\Claude\claude_desktop_config.json`                        |
+| Linux    | `~/.config/Claude/claude_desktop_config.json`                        |
+
+Create the file if it does not exist.
+
+#### 2. Add the domonda MCP server
+
+Edit `claude_desktop_config.json` and add (or merge) the `domonda` entry under
+`mcpServers`. See `claude_desktop_config.json.example` for a ready-to-copy
+template.
+
+```json
+{
+  "mcpServers": {
+    "domonda": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://domonda.app/api/mcp/",
+        "--header",
+        "Authorization: Bearer YOUR_API_KEY_HERE"
+      ]
+    }
+  }
+}
+```
+
+Replace `YOUR_API_KEY_HERE` with your actual domonda JWT API key.
+
+> **Base URL.** In production the domonda-web-server lives behind an `/api`
+> path prefix, so the MCP endpoint is `https://domonda.app/api/mcp/`. When
+> you run the web server locally there is **no** `/api` prefix — the endpoint
+> is `http://localhost:5001/mcp/` (5001 is the default port; override with
+> `PORT=…`).
+
+For local development, replace the URL with your local endpoint (note the
+missing `/api` segment):
+
+```json
+{
+  "mcpServers": {
+    "domonda": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "http://localhost:5001/mcp/",
+        "--header",
+        "Authorization: Bearer YOUR_API_KEY_HERE"
+      ]
+    }
+  }
+}
+```
+
+#### 3. Restart Claude Desktop
+
+Quit and reopen Claude Desktop for the configuration to take effect.
+The domonda tools should appear in the tool picker (hammer icon).
+
+## Cowork and claude.ai
+
+[Claude Cowork](https://claude.com/product/cowork) and the
+[claude.ai](https://claude.ai/) web app use the same Custom Connector flow as
+Option 1. Open Settings → Connectors (direct link:
+[claude.ai/settings/connectors](https://claude.ai/settings/connectors)), click
+**Add custom connector**, paste `https://domonda.app/api/mcp/`, and complete
+the Auth0 OAuth prompt. Any connector you add at claude.ai is also available
+inside Claude Desktop and Cowork on the same account.
+
+> See the [Claude custom connectors help article](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp)
+> for the latest plan-by-plan details, as the UI may change.
+
+## Verify Connectivity
+
+### Health check script
+
+```bash
+ export DOMONDA_API_KEY="your-api-key-here"   # leading space keeps this out of shell history
+./scripts/health_check.sh
+```
+
+Expected output:
+
+```
+Checking https://domonda.app/api/mcp/ ...
+OK (HTTP 200)
+```
+
+### Inside Claude Desktop
+
+Start a new conversation and ask:
+
+> "Use the domonda tools to get company info."
+
+Claude should call `get_my_company` and return your company details.
+
+## Usage
+
+Once configured, Claude can call any of the 28 domonda tools.
+See `SKILL.md` for the complete tool reference with parameters.
+
+### Recommended first steps
+
+1. **`list_capabilities`** — When unsure which tool fits, get a grouped
+   catalog of all available tools first.
+2. **`get_my_company`** — Confirm authentication and see which company the
+   API key is scoped to.
+3. **`list_tables`** / **`describe_table`** — Explore the available database
+   schema before writing queries.
+4. **`list_documents`** or **`list_invoices`** — Browse recent data.
+5. **`execute_query`** — Run ad-hoc read-only SQL for anything the specialized
+   tools don't cover.
+
+### Tool categories
+
+| Category  | Tools                                                                                                                                                                      |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Discovery | `list_capabilities`                                                                                                                                                        |
+| Schema    | `list_tables`, `describe_table`                                                                                                                                            |
+| Query     | `execute_query`                                                                                                                                                            |
+| Documents | `list_documents`, `get_document`, `get_document_fulltext`, `search_documents`, `download_document_pdf`, `get_document_thumbnail`, `get_document_preview`, `add_document` (write) |
+| Invoices  | `list_invoices`, `get_invoice`                                                                                                                                             |
+| Payments  | `list_money_accounts`, `list_money_transactions`, `get_invoice_payments`                                                                                                   |
+| Company   | `get_my_company`, `list_document_categories`, `list_gl_accounts`, `list_partner_companies`                                                                                 |
+| User      | `get_user`                                                                                                                                                                 |
+| Workflows | `list_document_workflows`, `list_document_workflow_steps`, `list_document_workflow_states`                                                                                 |
+| App URLs  | `get_app_urls`, `get_document_urls`, `get_document_selection_url`                                                                                                          |
+
+### Example prompts
+
+- "Show me all invoices from January 2026 over 1,000"
+- "Download the PDF for document 8a2f..."
+- "Which GL accounts are in use?"
+- "Search documents for 'electricity bill'"
+- "Run a query to find the top 10 partners by invoice count"
+- "Upload this invoice PDF into the OTHER_DOCUMENTS category"
+
+## Authentication
+
+The domonda MCP server uses **Streamable HTTP** transport with **Bearer token**
+authentication. Two token types are supported:
+
+1. **API key (HS256 JWT)** — the standard domonda API key. The JWT `sub` claim
+   identifies the client company directly. This is the simplest option for
+   programmatic access.
+2. **OAuth (Auth0 RS256)** — an Auth0 access token issued for the MCP resource.
+   The token's Auth0 `sub` claim is mapped to a Domonda user, who must be
+   enabled and have access to the target company. Supports the
+   `X-Selected-Client-Company-ID` header for multi-company users. Clients that
+   support OAuth discovery will be guided automatically via the
+   `WWW-Authenticate` header and the `.well-known/oauth-protected-resource`
+   metadata endpoint (RFC 9728).
+
+```
+Authorization: Bearer <DOMONDA_API_KEY_OR_OAUTH_TOKEN>
+```
+
+### OAuth client registration (CIMD, DCR, Anthropic-held credentials)
+
+When you add domonda through the Custom Connector UI, Claude has to register
+itself as an OAuth client with domonda's authorization server before the
+sign-in flow can run. Claude supports three registration approaches; domonda
+works with the first two **out of the box, no Auth0 changes required**:
+
+1. **Client ID Metadata Document (CIMD)** — *preferred, automatic.* Claude
+   uses an `https://` URL as its `client_id`; domonda's server fetches that
+   document and registers the client with Auth0 via DCR on Claude's behalf.
+   Claude selects CIMD automatically because domonda's authorization-server
+   metadata advertises **both** `"client_id_metadata_document_supported": true`
+   and `"none"` in `token_endpoint_auth_methods_supported` (required for a
+   public client). See the [main README CIMD section](../README.md#client-id-metadata-document-cimd).
+2. **Dynamic Client Registration (DCR, RFC 7591)** — *automatic fallback.*
+   Claude calls domonda's `/register` endpoint (proxied to Auth0) on each new
+   connection. Used automatically if the CIMD metadata above is ever missing.
+3. **Anthropic-held credentials** — *opt-in alternative, not needed for
+   domonda.* You email `mcp-review@anthropic.com` a `client_id` /
+   `client_secret` for a **confidential** Auth0 application you create against
+   the MCP API; Anthropic stores them and performs the token exchange on your
+   users' behalf during the consent flow. This trades per-connection
+   registration for one fixed set of credentials. domonda does not rely on
+   this path — CIMD/DCR already cover the Custom Connector UI — but it is
+   available if you ever want Anthropic to use fixed credentials instead.
+
+The server enforces:
+
+- **Read-only transactions for query tools** — no INSERT, UPDATE, DELETE, or DDL
+- **Schema restriction** — only the `api` schema is accessible
+- **Row limit** — max 1,000 rows per query
+- **Query timeout** — 30-second default
+- **Query length** — max 10,000 characters
+- **Writes are limited to `add_document`** — processed through the same OCR,
+  duplicate-detection, and category-ownership checks as the public API
+
+## Troubleshooting
+
+| Symptom                                             | Cause                                                       | Fix                                                                                       |
+|-----------------------------------------------------|-------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| Custom Connector can't reach `localhost:…`          | Connector dials from Anthropic's cloud, not your machine    | Switch to Option 2 (`mcp-remote` stdio bridge)                                            |
+| OAuth redirect fails / no OAuth prompt              | Using a local / non-public URL, or plan doesn't support it  | Use Option 2 with a raw JWT in the `Authorization` header                                 |
+| Tools don't appear (Option 2) in Claude Desktop     | Config file not found or malformed JSON                     | Verify the path and validate JSON syntax                                                  |
+| `npx` not found (Option 2)                          | Node.js not installed, or terminal opened before install    | See [What is `npx`?](#what-is-npx); install Node.js and restart the terminal              |
+| `mcp-remote` connection error (Option 2)            | Network or firewall issue                                   | Check internet connectivity; try `curl https://domonda.app/api/mcp/`                      |
+| HTTP 401                                            | Invalid, expired, or blocked token                          | Verify your API key or OAuth token; contact admin if blocked                              |
+| HTTP 403                                            | Forbidden company access or insufficient OAuth scopes       | Check the selected company or required scopes                                             |
+| HTTP 404                                            | Wrong endpoint URL                                          | Ensure the URL ends with `/mcp/` or `/mcp`                                                |
+| Query returns no rows                               | Company scoping — data belongs to another company           | Confirm `get_my_company` returns the expected company                                     |
+| `execute_query` rejected                            | SQL validation failed (DML, wrong schema)                   | Use only SELECT/WITH against the `api` schema                                             |

--- a/mcp/claude-desktop/SKILL.md
+++ b/mcp/claude-desktop/SKILL.md
@@ -1,0 +1,569 @@
+---
+name: domonda
+description: >
+  Use when you need to access domonda financial data — documents, invoices,
+  payments, money transactions, companies, GL accounts, partner companies,
+  and document workflows. Connects to the domonda MCP server via Streamable
+  HTTP with Bearer token authentication (API key or OAuth). All query tools
+  are read-only; the only write tool is `add_document`, which uploads a file
+  into the authenticated company's document pipeline.
+env:
+  - name: DOMONDA_API_KEY
+    required: true
+    secret: true
+    description: API key (HS256 JWT) or Auth0 OAuth access token for Bearer authentication
+  - name: DOMONDA_URL
+    required: false
+    secret: false
+    description: "Override domonda base URL (default: https://domonda.app)"
+---
+
+# domonda MCP Skill
+
+Connect to the [domonda](https://domonda.app) financial data platform via its MCP server.
+Query documents, invoices, payments, money transactions, companies, GL accounts, partner companies, and document workflows. All query tools are read-only; the only write tool is `add_document`, which uploads a file into the authenticated company's document pipeline.
+
+> **Language note.** The live MCP tool and parameter descriptions surfaced by
+> the server are written in **German**, including a "Nutzen wenn …" block of
+> trigger phrases. This matches the domonda-app UI and the natural vocabulary
+> of end users, and improves discoverability for clients (e.g. ChatGPT) that
+> match user prompts against tool descriptions by embedding similarity. The
+> English descriptions in this file are developer-facing reference only —
+> what your agent actually sees at runtime is the German text from the server.
+>
+> If you are unsure which tool to call, call `list_capabilities` first to get
+> a topic-grouped catalog of all available tools.
+
+## Agent Security Rules
+
+- **Never** display, log, or transmit the API key in plain text.
+- **Never** pass the API key as a CLI argument or embed it in URLs.
+- Only use the API key for authenticating against the domonda MCP endpoint.
+- Do not write, modify, or delete data via `execute_query` or any query tool — those tools are read-only and any DML will be rejected by the server.
+- The only write tool is `add_document`. Only call it when the user has explicitly asked you to upload a document. Never call it on your own initiative, and never use it to write arbitrary data.
+
+## Quick Start
+
+Pick one of:
+
+**a. Custom Connector UI (recommended, production, OAuth):**
+
+1. In Claude Desktop: **Settings → Connectors → Add custom connector**.
+2. URL: `https://domonda.app/api/mcp/`
+3. Complete the Auth0 OAuth prompt.
+
+**b. `mcp-remote` stdio bridge (localhost dev or raw JWT):**
+
+Edit `claude_desktop_config.json` and add:
+
+```json
+{
+  "mcpServers": {
+    "domonda": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://domonda.app/api/mcp/",
+        "--header",
+        "Authorization: Bearer YOUR_API_KEY_HERE"
+      ]
+    }
+  }
+}
+```
+
+Restart Claude Desktop afterwards. Verify endpoint connectivity with:
+
+```bash
+./scripts/health_check.sh
+```
+
+See `README.md` for when to choose which path.
+
+## Available Tools
+
+> The description paragraph for each tool below is written in **German**
+> (matching what the running MCP server actually surfaces to clients),
+> because domonda end users chat in German and tools are picked by
+> similarity to the user's prompt. The parameter tables and technical
+> notes stay in English.
+
+### Discovery
+
+#### `list_capabilities`
+
+Liefert einen nach Thema gruppierten Katalog ALLER verfügbaren Domonda-Tools
+mit einer kurzen deutschen Einzeiler-Beschreibung pro Tool. Dient als
+Einstiegspunkt: bei Unsicherheit, welches Tool passt, zuerst dieses
+aufrufen und dann das passende Tool direkt nutzen. Nutzen wenn der Benutzer
+nach "was kannst du", "welche Tools", "welche Werkzeuge", "hilf mir",
+"Übersicht", "Katalog", "was ist verfügbar", "Capabilities", "Hilfe" fragt.
+
+**Parameters:** None
+
+### Schema Tools
+
+#### `list_tables`
+
+Listet alle Tabellen und Views im `api`-Schema der Domonda-Datenbank (Name,
+Typ Tabelle/View, Beschreibung). Nutzen für Datenmodell-Exploration, bevor
+eine benutzerdefinierte Abfrage via `execute_query` gebaut wird, oder wenn
+der Benutzer nach "welche Tabellen gibt es", "Datenmodell", "Schema", "was
+ist in der DB" fragt.
+
+**Parameters:** None
+
+#### `describe_table`
+
+Beschreibt die Spalten einer Tabelle oder View im `api`-Schema:
+Spaltennamen, Datentypen, NULL-Zulässigkeit, Default-Werte. Nutzen bevor
+eine `SELECT`-Abfrage via `execute_query` geschrieben wird, um die
+verfügbaren Spalten zu kennen, oder wenn der Benutzer nach "welche
+Spalten", "Struktur der Tabelle", "Felder" fragt.
+
+| Parameter    | Type   | Required | Description                                                                                     |
+|------------- |--------|----------|-------------------------------------------------------------------------------------------------|
+| `table_name` | string | yes      | Name of the table or view in the `api` schema (e.g. `invoice`, `document`, `partner_company`)   |
+
+### Query Tools
+
+#### `execute_query`
+
+Führt eine READ-ONLY SQL-Abfrage (`SELECT` oder `WITH`) gegen das
+`api`-Schema der Domonda-Datenbank aus. Nur das `api`-Schema ist zugänglich;
+`pg_catalog`, `information_schema` und andere Schemata werden abgelehnt.
+Unqualifizierte Tabellennamen werden ins `api`-Schema aufgelöst. Ergebnis:
+JSON-Array von Objekten, maximal 1000 Zeilen. Daten sind automatisch auf
+den angemeldeten Mandanten eingeschränkt. Nutzen nur wenn die
+spezialisierten Tools (`list_documents`, `list_invoices`,
+`list_money_transactions`, …) nicht ausreichen und eine eigene Abfrage
+nötig ist. Vorher `list_tables` und `describe_table` nutzen, um das Schema
+zu erkunden.
+
+| Parameter | Type   | Required | Description                                                                                        |
+|-----------|--------|----------|----------------------------------------------------------------------------------------------------|
+| `sql`     | string | yes      | The SQL query to execute. Must start with `SELECT` or `WITH`. Only the `api` schema is accessible. |
+
+### Document Tools
+
+#### `list_documents`
+
+Sucht, filtert und listet Dokumente des Mandanten: Rechnungen, Verträge,
+Belege, Lieferscheine, Kontoauszüge, sonstige Dokumente, DMS. Unterstützt
+Volltextsuche, Datumsbereiche (mehrere Datumstypen), Beträge, Zahl- und
+Exportstatus, Geschäftspartner, Kategorien, Dokumentarten,
+Genehmigungsstatus, Duplikate, Kommentare, Vertragstypen und konfigurierbare
+Sortierung. Nutzen wenn der Benutzer nach "Dokumente", "Belege",
+"Rechnungen", "Verträge", "Lieferscheine", "Kontoauszüge", "Mahnungen",
+"was liegt im Eingang", "Dokumentenliste", "welche Dokumente gibt es zu …",
+"suche Beleg über …", "offene Rechnungen", "nicht freigegebene", "nicht
+exportierte" fragt. Für reine Volltextsuche ohne Filter siehe
+`search_documents`.
+
+All filter parameters are optional; omitting a parameter lets the server default apply.
+
+| Parameter                | Type            | Description                                                                                                               |
+|--------------------------|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| `limit`                  | number          | Maximum number of documents to return (default 50, max 1000)                                                              |
+| `offset`                 | number          | Number of documents to skip for pagination                                                                                |
+| `search_text`            | string          | Fulltext search over the extracted document content (OCR + structured data)                                               |
+| `archived`               | string enum     | `exclude` (default, only active), `only` (only archived), or `include` (both)                                             |
+| `has_warning`            | boolean         | `true`: only documents with a warning; `false`: only documents without                                                    |
+| `internal_number`        | string          | Filter by domonda-internal sequential document number                                                                     |
+| `date_filter_type`       | string enum     | Which date `from_date`/`until_date` apply to: `DOCUMENT_DATE`, `INVOICE_DATE` (default), `IMPORT_DATE`, `DUE_DATE`, `DISCOUNT_DUE_DATE`, `PAID_DATE`, `DELIVERED_DATE` |
+| `from_date`              | string          | Lower bound (inclusive) for the date selected via `date_filter_type` (YYYY-MM-DD)                                         |
+| `until_date`             | string          | Upper bound (inclusive) for the date selected via `date_filter_type` (YYYY-MM-DD)                                         |
+| `min_total`              | number          | Only documents with invoice gross total ≥ this amount                                                                     |
+| `max_total`              | number          | Only documents with invoice gross total ≤ this amount                                                                     |
+| `export_status`          | string enum     | Accounting export status (exported / not exported, for "booking" or "ready for booking"; see tool schema for the full enum) |
+| `paid_status`            | string enum     | Invoice payment status: paid, partially paid, not paid, not payable, or paid via a specific payment method                 |
+| `document_types`         | string[] enum   | One or more document types (incoming/outgoing invoice, dunning letter, delivery note, bank/credit-card statement, other document, DMS, …) |
+| `document_category_ids`  | string[] (UUID) | One or more document category IDs (from `list_document_categories`)                                                        |
+| `partner_company_ids`    | string[] (UUID) | One or more partner company IDs (customer or supplier, from `list_partner_companies`)                                      |
+| `is_credit_memo`         | boolean         | `true`: only credit memos (Gutschriften); `false`: exclude credit memos                                                    |
+| `has_pain001_payment`    | boolean         | `true`: only documents with a generated SEPA credit transfer (PAIN.001); `false`: without                                  |
+| `has_pain008_direct_debit` | boolean       | `true`: only documents with a generated SEPA direct debit (PAIN.008); `false`: without                                     |
+| `is_payment_reminder_sent` | boolean       | `true`: only documents for which a payment reminder/dunning letter has already been sent                                   |
+| `is_approved`            | boolean         | `true`: only approved documents; `false`: only not-yet-approved documents (waiting for workflow approval)                  |
+| `is_duplicate`           | boolean         | `true`: only documents detected as duplicates; `false`: only non-duplicates                                                |
+| `has_comments`           | boolean         | `true`: only documents with comments; `false`: without                                                                     |
+| `is_recurring`           | boolean         | `true`: only recurring documents; `false`: only one-off documents                                                          |
+| `contract_type`          | string enum     | Contract type filter for `OTHER_DOCUMENT`s (service contracts, rental contracts, insurance, …; see tool schema)            |
+| `order_bys`              | string[] enum   | Ordering rules applied in sequence; default `IMPORT_DATE_DESC` (most recently imported first)                              |
+
+> The full enum values for `export_status`, `paid_status`, `document_types`, `contract_type`, and `order_bys` are exposed on the live tool schema — your MCP client will surface them.
+
+#### `get_document`
+
+Liefert Metadaten eines einzelnen Dokuments anhand seiner UUID: Dokumentart,
+Kategorie, Geschäftspartner, Datum, Status, Beträge (soweit vorhanden).
+Enthält **nicht** den Volltext — siehe `get_document_fulltext` für den
+extrahierten OCR-Text oder `get_invoice` für Rechnungs-Positionen. Nutzen
+wenn der Benutzer nach "Details zum Dokument", "Info zu diesem Beleg", "was
+ist das für ein Dokument", "wer hat das hochgeladen", "welche Kategorie"
+fragt.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_fulltext`
+
+Liefert den extrahierten Volltext (OCR) eines Dokuments. Nutzen wenn der
+Benutzer den kompletten Inhalt eines Dokuments lesen will — "Volltext",
+"was steht im Beleg", "OCR-Text", "Inhalt dieses Dokuments".
+
+**Warning:** fulltexts can be very large; long documents may approach or
+exceed the MCP response byte cap (default 10 MiB)
+and the call will fail. For pure search prefer `search_documents` and only
+fetch the fulltext of a specific hit when really needed.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `search_documents`
+
+Volltextsuche über alle Dokumente des Mandanten; Treffer sind nach Relevanz
+sortiert. Nutzen wenn der Benutzer etwas FINDEN will, statt gezielt zu
+filtern — z. B. "finde Beleg über Büromöbel", "such mir alles zu Projekt
+X", "gibt es eine Rechnung mit …", "wo taucht der Begriff … auf". Für
+strukturierte Filter (Datum, Partner, Status, Beträge) lieber
+`list_documents` verwenden.
+
+| Parameter | Type   | Required | Description                                          |
+|-----------|--------|----------|------------------------------------------------------|
+| `query`   | string | yes      | Search term or phrase for the fulltext search        |
+| `limit`   | number | no       | Maximum number of results (default: 20, max: 1000)   |
+
+#### `download_document_pdf`
+
+Lädt die Original-PDF-Datei eines Dokuments herunter — optional mit
+angehängtem oder vorangestelltem Audit-Trail (Protokoll der
+Bearbeitungsschritte, Freigaben, Änderungen). Standard: die PDF-Bytes
+werden base64-kodiert inline zurückgegeben. Mit `inline: false` wird
+stattdessen ein MCP `resource_link` auf `document://{document_id}/pdf?...`
+geliefert, den ein resource-fähiger Client via `resources/read` nachladen
+kann. Nutzen wenn der Benutzer "die PDF", "das Original", "den Beleg
+herunterladen", "Rechnung als PDF", "mit Audit-Trail" sagt.
+
+| Parameter          | Type    | Required | Description                                                                        |
+|--------------------|---------|----------|------------------------------------------------------------------------------------|
+| `document_id`      | string  | yes      | The UUID of the document                                                           |
+| `audit_trail`      | string  | no       | Audit-trail position in the PDF: `append`, `prepend`, `configured` (mandant setting), or `only` (audit trail only). Empty = no audit trail. |
+| `audit_trail_lang` | string  | no       | Language of the audit trail as ISO 639-1 code (default `de`)                       |
+| `inline`           | boolean | no       | `true` (default): return the PDF bytes inline as a base64-encoded resource. `false`: return an MCP `resource_link` to `document://{document_id}/pdf?...` that a resource-aware client loads via `resources/read`. |
+
+The PDF is also exposed as an MCP resource at `document://{document_id}/pdf{?audit_trail,audit_trail_lang}`, so resource-aware clients can fetch it via `resources/read`. The `configured` audit-trail value is resolved to `append`/`prepend` before a resource link is returned, so resource URIs are deterministic and cacheable.
+
+#### `get_document_thumbnail`
+
+Liefert die kleine Miniaturansicht (JPEG, 256 px breit, Seitenverhältnis
+erhalten) eines Dokuments als base64-kodierten Blob. Auch als MCP-Ressource
+unter `document://{document_id}/thumb_256x0.jpeg` verfügbar. Nutzen wenn
+der Benutzer eine schnelle Vorschau, ein Miniaturbild oder ein "Icon" eines
+Dokuments sehen will. Für eine größere Vorschau siehe `get_document_preview`.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_preview`
+
+Liefert die große Vorschau (JPEG, 964×1364) eines Dokuments als
+base64-kodierten Blob — das größte vorgerenderte Vorschaubild. Auch als
+MCP-Ressource unter `document://{document_id}/preview.jpeg` verfügbar.
+Nutzen wenn der Benutzer "zeig mir das Dokument", "Vorschau", "wie sieht
+der Beleg aus", "Bild des Dokuments" sagt. Für eine kleinere Miniaturansicht
+siehe `get_document_thumbnail`; für die Original-PDF siehe
+`download_document_pdf`.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `add_document` (write)
+
+Lädt ein neues Dokument (Rechnung, Beleg, Vertrag, Lieferschein, sonstige
+Datei) für den angemeldeten Mandanten hoch. Dubletten-Erkennung und
+Kategorie-Zuweisung laufen automatisch. Nutzen wenn der Benutzer "Dokument
+hochladen", "Beleg importieren", "Rechnung hinzufügen", "upload", "neues
+Dokument", "Datei einspielen" sagt. Vorher `list_document_categories`
+aufrufen, um eine gültige `category_id` zu ermitteln.
+
+Supported file types: PDF, PNG, JPEG, TIFF, XML, HTML, RTF, DOC, DOCX, ODT,
+XLS, XLSX, ODS. This is the **only write operation** on the MCP server; the
+file is processed through the same pipeline as the public upload endpoint.
+Returns the new document UUID on success.
+
+| Parameter                 | Type    | Required | Description                                                                                |
+|---------------------------|---------|----------|--------------------------------------------------------------------------------------------|
+| `file_data`               | string  | yes      | Base64-encoded file content (no URL, no path — the raw bytes base64-encoded)                |
+| `filename`                | string  | yes      | Original filename including extension (e.g. `invoice_2026_04.pdf`)                         |
+| `category_id`             | string  | yes      | Document category UUID (use `list_document_categories` to find valid IDs)                  |
+| `tags`                    | string[]| no       | Optional document tags                                                                     |
+| `allow_duplicate_deleted` | boolean | no       | If `true`, allow re-uploading a file whose hash matches a previously-deleted document. Default `false`. |
+| `wait_for_extraction`     | boolean | no       | If `true`, wait synchronously for OCR/extraction before returning. Default `false` (asynchronous). |
+
+> **Agent guidance:** Only call `add_document` when the user has explicitly asked you to upload a file. Do not use it on your own initiative.
+
+### Invoice Tools
+
+#### `list_invoices`
+
+Listet Rechnungen des Mandanten (Eingangs- und Ausgangsrechnungen, inkl.
+Gutschriften) mit Rechnungsnummer, Rechnungsdatum, Fälligkeitsdatum,
+Geschäftspartner, Netto, Brutto, Währung, USt-Satz, Zahlstatus, offenem
+Betrag und Buchungsstatus. Filter: Datumsbereich, Partner-Name,
+Mindest-/Maximalbetrag. Nutzen wenn der Benutzer nach "Rechnungen",
+"Eingangsrechnungen", "Ausgangsrechnungen", "ER", "AR", "Gutschriften",
+"offene Posten", "Forderungen", "Verbindlichkeiten", "unbezahlte
+Rechnungen", "Rechnungen von <Firma>" fragt. Für einzelne Rechnungsdetails
+siehe `get_invoice`.
+
+| Parameter      | Type   | Required | Description                                                                                                  |
+|----------------|--------|----------|--------------------------------------------------------------------------------------------------------------|
+| `limit`        | number | no       | Maximum number of invoices to return (default: 50, max: 1000)                                                |
+| `offset`       | number | no       | Number of invoices to skip for pagination (default: 0)                                                       |
+| `from_date`    | string | no       | Lower bound (inclusive) for the invoice date (YYYY-MM-DD)                                                    |
+| `until_date`   | string | no       | Upper bound (inclusive) for the invoice date (YYYY-MM-DD)                                                    |
+| `partner_name` | string | no       | Filter by partner company name (customer or supplier, case-insensitive partial match)                        |
+| `min_total`    | number | no       | Only invoices with gross total ≥ this amount                                                                 |
+| `max_total`    | number | no       | Only invoices with gross total ≤ this amount                                                                 |
+
+#### `get_invoice`
+
+Liefert alle Details zu einer einzelnen Rechnung: Kopfdaten, Positionen
+(Line Items), Skonto, Fälligkeit, umgerechnete EUR-Beträge, Geschäftspartner,
+UID/VAT-ID des Partners, zugeordnete Zahlungen. Nutzen wenn der Benutzer
+eine konkrete Rechnung im Detail sehen will — "zeig mir Rechnung …",
+"Details zu dieser Rechnung", "was steht auf der Rechnung", "Positionen",
+"Line Items", "Skonto", "Fälligkeit". Für eine Liste mehrerer Rechnungen
+siehe `list_invoices`.
+
+| Parameter     | Type   | Required | Description                                                                   |
+|---------------|--------|----------|-------------------------------------------------------------------------------|
+| `document_id` | string | yes      | The UUID of the invoice's document (from `list_invoices` or `list_documents`) |
+
+### Payment Tools
+
+#### `list_money_accounts`
+
+Listet alle Bankkonten und Zahlungskonten des Mandanten: Bankkonten,
+Kreditkarten, PayPal, Wise, Kassa. Nutzen wenn der Benutzer nach
+"Bankkonto", "Bankkonten", "Konten", "Kreditkarte", "PayPal", "Kassa",
+"welche Konten haben wir", "IBAN" fragt — oder wenn eine Kontoauswahl für
+weitere Filter benötigt wird.
+
+**Parameters:** None
+
+#### `list_money_transactions`
+
+Listet Banktransaktionen und Kreditkartenbewegungen des Mandanten mit
+Betrag, Währung, Buchungsdatum, Valutadatum, Empfänger/Zahler,
+Verwendungszweck und Typ (EINGEHEND/AUSGEHEND). Filter: Konto, Typ,
+Datumsbereich, Partner-Name. Nutzen wenn der Benutzer nach "Transaktionen",
+"Banktransaktionen", "Buchungen auf dem Konto", "Kontoauszug", "Ein- und
+Ausgänge", "Zahlungseingang", "Zahlungsausgang", "Umsätze" fragt.
+
+| Parameter      | Type   | Required | Description                                                           |
+|----------------|--------|----------|-----------------------------------------------------------------------|
+| `limit`        | number | no       | Maximum number of transactions to return (default: 50, max: 1000)     |
+| `offset`       | number | no       | Number of transactions to skip for pagination (default: 0)            |
+| `account_id`   | string | no       | Filter to a specific money account (UUID from `list_money_accounts`)  |
+| `type`         | string | no       | Filter by direction: `INCOMING` (credit) or `OUTGOING` (debit)        |
+| `from_date`    | string | no       | Lower bound (inclusive) for the booking date (YYYY-MM-DD)             |
+| `until_date`   | string | no       | Upper bound (inclusive) for the booking date (YYYY-MM-DD)             |
+| `partner_name` | string | no       | Text filter on the counterparty name (case-insensitive partial match) |
+
+#### `get_invoice_payments`
+
+Liefert alle Zahlungen (Banktransaktionen), die einer bestimmten Rechnung
+zugeordnet sind, inkl. offenem Betrag, bereits verrechneter Summe,
+Zahlstatus und Zahldatum. Nutzen wenn der Benutzer nach "Zahlungen zur
+Rechnung", "ist bezahlt", "offener Betrag", "welche Zahlung wurde
+zugeordnet", "Zahlungsabgleich", "Payment Matching" für eine konkrete
+Rechnung fragt.
+
+| Parameter     | Type   | Required | Description                                                                   |
+|---------------|--------|----------|-------------------------------------------------------------------------------|
+| `document_id` | string | yes      | The UUID of the invoice's document (from `list_invoices` or `list_documents`) |
+
+### Company Tools
+
+#### `get_my_company`
+
+Liefert die Stammdaten des eigenen Mandanten (angemeldete Firma):
+Firmenname, Rechtsform, Hauptsitz/Adresse, Telefon, E-Mail, Website,
+UID/VAT-Nummer, Steuernummer, Handelsregister-Nummer. Nutzen wenn der
+Benutzer nach "meine Firma", "mein Mandant", "unsere Firma", "Firmendaten",
+"Stammdaten", "UID", "VAT-ID", "Steuernummer", "Firmenadresse", "Hauptsitz",
+"wer sind wir" fragt.
+
+**Parameters:** None
+
+#### `list_document_categories`
+
+Listet alle Dokumentenkategorien des Mandanten (visuelle Kategorien für
+die Ablage). Nutzen wenn der Benutzer nach "Kategorien",
+"Dokumentenkategorien", "Ablagekategorien", "welche Kategorien gibt es",
+"wo wird abgelegt" fragt oder bevor ein Dokument via `add_document`
+hochgeladen wird, um eine gültige `category_id` zu ermitteln.
+
+**Parameters:** None
+
+#### `list_gl_accounts`
+
+Listet alle Sachkonten (GL accounts, Hauptbuchkonten) des Mandanten mit
+Nummer und Bezeichnung. Nutzen wenn der Benutzer nach "Sachkonto",
+"Sachkonten", "Kontenplan", "Buchungskonto", "GL account", "general
+ledger", "Hauptbuch", "Kontonummer" fragt — typischerweise für
+Buchhaltung, Kontierung und Accounting-Export.
+
+**Parameters:** None
+
+#### `list_partner_companies`
+
+Listet Geschäftspartner des Mandanten: Kunden, Lieferanten, Debitoren,
+Kreditoren — mit Namen, abgeleitetem Namen, Debitoren- und
+Kreditoren-Kontonummer. Optional nach Namen filterbar. Nutzen wenn der
+Benutzer nach "Kunde", "Kunden", "Lieferant", "Lieferanten",
+"Geschäftspartner", "Partner", "Debitor", "Kreditor", "vendor",
+"supplier", "customer" fragt.
+
+| Parameter     | Type   | Required | Description                                                                                    |
+|---------------|--------|----------|------------------------------------------------------------------------------------------------|
+| `search_text` | string | no       | Optional text filter: partner companies whose name contains this substring (case-insensitive)  |
+| `limit`       | number | no       | Maximum number of results (default: 50, max: 1000)                                             |
+
+### User Tools
+
+#### `get_user`
+
+Liefert den aktuell angemeldeten Benutzer (Name, E-Mail, Sprache, Mandant).
+Nutzen wenn der Benutzer nach "wer bin ich", "mein Profil", "mein Konto",
+"Benutzer", "User", "angemeldet" fragt oder wenn ein anderes Tool die
+aktuelle Benutzer-ID benötigt. Funktioniert nur bei OAuth-Login —
+API-Key-Zugriff liefert hier einen Fehler, weil der Key einen Mandanten
+identifiziert, keinen Benutzer.
+
+**Parameters:** None
+
+### Workflow Tools
+
+#### `list_document_workflows`
+
+Listet alle im Mandanten konfigurierten Dokument-Workflows
+(Freigabe-Prozesse) mit Namen und IDs. Ein Workflow ist ein Ablauf, den
+ein Dokument durchläuft, bestehend aus mehreren Workflow-Schritten. Nutzen
+wenn der Benutzer nach "Workflows", "Freigabe-Prozess",
+"Genehmigungsprozess", "Approval-Flow", "welche Workflows gibt es" fragt.
+Für die einzelnen Schritte eines Workflows siehe
+`list_document_workflow_steps`.
+
+| Parameter | Type   | Required | Description                                                |
+|-----------|--------|----------|------------------------------------------------------------|
+| `limit`   | number | no       | Maximum number of rows to return (default: 100, max: 1000) |
+| `offset`  | number | no       | Number of rows to skip for pagination (default: 0)         |
+
+#### `list_document_workflow_steps`
+
+Listet Workflow-Schritte des Mandanten (einzelne Stationen eines
+Freigabe-Workflows). Ein Dokument steht zu jedem Zeitpunkt in genau einem
+Workflow-Schritt. Nutzen wenn der Benutzer nach "Workflow-Schritten",
+"Freigabeschritten", "Genehmigungsstufen", "welche Schritte hat unser
+Workflow", "Approval-Steps" fragt. Für den aktuellen Schritt konkreter
+Dokumente siehe `list_document_workflow_states`.
+
+| Parameter     | Type   | Required | Description                                                                                   |
+|---------------|--------|----------|-----------------------------------------------------------------------------------------------|
+| `workflow_id` | string | no       | Optional: UUID of a specific workflow to list only its steps (from `list_document_workflows`) |
+| `limit`       | number | no       | Maximum number of rows to return (default: 100, max: 1000)                                    |
+| `offset`      | number | no       | Number of rows to skip for pagination (default: 0)                                            |
+
+#### `list_document_workflow_states`
+
+Liefert den AKTUELLEN Workflow-Zustand von Dokumenten: in welchem
+Workflow-Schritt steht ein Dokument gerade, und wie lautet sein Status.
+Eine Zeile pro Dokument. Nutzen wenn der Benutzer nach "Wo steht das
+Dokument gerade", "in welchem Schritt", "Freigabestatus", "wartet auf
+Freigabe von …", "welche Dokumente hängen wo", "Workflow-Status" fragt.
+
+| Parameter     | Type   | Required | Description                                                            |
+|---------------|--------|----------|------------------------------------------------------------------------|
+| `document_id` | string | no       | Optional: UUID of a single document to return only its workflow state  |
+| `limit`       | number | no       | Maximum number of rows to return (default: 50, max: 1000)              |
+| `offset`      | number | no       | Number of rows to skip for pagination (default: 0)                     |
+
+### App URL Tools
+
+#### `get_app_urls`
+
+Liefert Deep-Links in die Domonda Web-App, zugeschnitten auf den
+angemeldeten Mandanten: Dokumente-Übersicht, Bank (Banking),
+Buchhaltungsansicht, Workflows/Freigaben, Academy (Hilfe/Doku),
+API-Repository. Nutzen wenn der Benutzer "öffne in Domonda", "zeig mir in
+der App", "Link zu …", "wo finde ich das", "geh in die Bank-Ansicht",
+"geh in die Buchhaltung" sagt.
+
+- `documents_overview` — main documents list
+- `banking` — banking overview
+- `accounting` — documents list with accounting view
+- `workflows` — documents list with workflow view (unapproved)
+- `documentation` — user-facing documentation (academy)
+- `api` — public API repository
+
+**Parameters:** None
+
+#### `get_document_urls`
+
+Liefert Deep-Links in die Domonda Web-App für EIN einzelnes Dokument: Tabs
+Prüfung (`review`), Zahlung (`payment`), Buchhaltung (`accounting`) und
+Zusammenarbeit (`collaboration`). Nutzen wenn der Benutzer "öffne dieses
+Dokument in Domonda", "Link zum Beleg", "spring zu
+Zahlung/Buchhaltung/Prüfung" für ein konkretes Dokument sagt. Das Dokument
+muss zum angemeldeten Mandanten gehören.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_selection_url`
+
+Liefert Deep-Links in die Domonda Web-App, die eine Auswahl MEHRERER
+Dokumente gemeinsam öffnen — je eine URL pro Mehrfach-Ansicht:
+`thumb_view` (Miniaturansicht), `list_view` (Listenansicht),
+`accounting_view` (Buchhaltungsansicht), `workflow_view` (Freigabenansicht).
+Nutzen wenn der Benutzer "öffne diese Rechnungen in Domonda", "zeig mir
+diese Belege in der App", "Link zu diesen Dokumenten",
+"Buchhaltungsansicht für diese Dokumente" sagt. Alle Dokumente müssen zum
+angemeldeten Mandanten gehören.
+
+URLs use the `?documentRowIds[]=<uuid>&view=<VIEW>` schema consumed by the
+domonda-app frontend routing; document ownership is verified per-id on the
+server.
+
+| Parameter      | Type            | Required | Description                                                              |
+|----------------|-----------------|----------|--------------------------------------------------------------------------|
+| `document_ids` | string[] (UUID) | yes      | List of document UUIDs to open together in the selection (at least one) |
+
+## Authentication
+
+The domonda MCP server uses JWT Bearer token authentication. The API key is a JWT where the `sub` claim contains the client company ID. All queries execute within a read-only, company-scoped database transaction.
+
+Pass the token in the HTTP `Authorization` header:
+
+```
+Authorization: Bearer <your-api-key>
+```
+
+## Usage Tips
+
+- Start with `get_my_company` to confirm connectivity and see which company you are authenticated as.
+- Use `list_tables` and `describe_table` for schema discovery before writing queries.
+- Use `execute_query` for ad-hoc SQL queries when the specialized tools don't cover your use case.
+- All date parameters use `YYYY-MM-DD` format.
+- UUID parameters must be valid UUID strings.
+- Results are capped at 1000 rows — use `limit` and `offset` for pagination.
+- `offset` is clamped to 100,000; stream beyond that by narrowing filters (date range, partner, status) instead of paginating deeper.
+- `execute_query` rejects SQL longer than 10,000 characters.

--- a/mcp/claude-desktop/claude_desktop_config.json.example
+++ b/mcp/claude-desktop/claude_desktop_config.json.example
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "domonda": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://domonda.app/api/mcp/",
+        "--header",
+        "Authorization: Bearer YOUR_API_KEY_HERE"
+      ]
+    }
+  }
+}

--- a/mcp/claude-desktop/scripts/health_check.sh
+++ b/mcp/claude-desktop/scripts/health_check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source .env if present
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+# In production the domonda-web-server is mounted behind an /api path prefix,
+# so the MCP endpoint is https://domonda.app/api/mcp/. When running the web
+# server locally there is no /api prefix — use MCP_ENDPOINT to override, e.g.
+#   MCP_ENDPOINT=http://localhost:5001/mcp/ ./scripts/health_check.sh
+DOMONDA_URL="${DOMONDA_URL:-https://domonda.app}"
+MCP_ENDPOINT="${MCP_ENDPOINT:-${DOMONDA_URL}/api/mcp/}"
+
+if [ -z "${DOMONDA_API_KEY:-}" ]; then
+  echo "Error: DOMONDA_API_KEY is not set."
+  echo "Set it in your environment or in .env"
+  exit 1
+fi
+
+echo "Checking ${MCP_ENDPOINT} ..."
+
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer ${DOMONDA_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"health-check","version":"1.0.0"}}}' \
+  "${MCP_ENDPOINT}")
+
+if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+  echo "OK (HTTP ${HTTP_STATUS})"
+else
+  echo "FAILED (HTTP ${HTTP_STATUS})"
+  exit 1
+fi

--- a/mcp/openclaw/.env.example
+++ b/mcp/openclaw/.env.example
@@ -1,0 +1,5 @@
+# JWT API key (obtain from Domonda admin panel)
+DOMONDA_API_KEY=
+
+# Optional: Override base URL for local development (default: https://domonda.app)
+# DOMONDA_URL=http://localhost:8080

--- a/mcp/openclaw/README.md
+++ b/mcp/openclaw/README.md
@@ -1,0 +1,209 @@
+# domonda MCP — OpenClaw Skill & Plugin
+
+This directory contains an [OpenClaw](https://openclaw.ai) skill that connects
+AI agents to the [domonda](https://domonda.app) financial data platform via its
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server.
+
+Query tools are **read-only**. The skill exposes 28 tools covering documents,
+invoices, payments, money transactions, companies, GL accounts, partner
+companies, document workflows, web app deep links, ad-hoc SQL queries, and a
+`list_capabilities` discovery tool. The single write tool is `add_document`,
+which uploads a file into the authenticated company's document pipeline.
+
+> **Live tool descriptions are in German.** The tool and parameter
+> descriptions surfaced by the running MCP server (and therefore what your
+> agent actually matches against user prompts) are written in German with
+> domain vocabulary pulled from the domonda-app UI (Sachkonto, Rechnung,
+> Gutschrift, Geschäftspartner, Fälligkeitsdatum, Mandant, Freigabe, …) and
+> a "Nutzen wenn …" trigger-phrase block for each tool. End users chat in
+> German, so the descriptions are optimised for the words they actually
+> use. Agents that are uncertain which tool to call should call
+> `list_capabilities` first for a topic-grouped catalog.
+
+## Prerequisites
+
+- An OpenClaw account and a configured agent
+- A domonda API key (JWT) or an Auth0 OAuth access token for the MCP resource
+- `curl` (for the health check script)
+
+## Directory Structure
+
+```
+openclaw/
+├── SKILL.md                  # Skill definition (frontmatter + tool reference)
+├── .env.example              # Environment variable template
+├── openclaw.json.example     # OpenClaw MCP server configuration template
+├── scripts/
+│   └── health_check.sh       # Connectivity check script
+└── README.md                 # This file
+```
+
+## Installation
+
+### 1. Register the skill in OpenClaw
+
+Add the `domonda` skill to your OpenClaw agent. Point it at the `SKILL.md`
+file in this directory — OpenClaw reads the YAML frontmatter to discover the
+skill name, description, and required environment variables.
+
+### 2. Set up environment variables
+
+Copy the example and fill in your API key:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```
+DOMONDA_API_KEY=eyJhbGciOiJSUzI1NiIs...    # your JWT API key
+```
+
+| Variable          | Required | Description                                              |
+|-------------------|----------|----------------------------------------------------------|
+| `DOMONDA_API_KEY` | yes      | JWT API key for Bearer token authentication              |
+| `DOMONDA_URL`     | no       | Override base URL (default: `https://domonda.app`)       |
+
+> **Security:** Never commit `.env` to version control. The `.env` file is
+> listed in `.gitignore`. The API key is a secret and must not be logged,
+> displayed, or passed as a CLI argument.
+
+### 3. Configure the MCP server connection
+
+Copy the example configuration:
+
+```bash
+cp openclaw.json.example openclaw.json
+```
+
+The default configuration connects to the production domonda MCP endpoint:
+
+```json
+{
+  "mcpServers": {
+    "domonda": {
+      "url": "https://domonda.app/api/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${DOMONDA_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+OpenClaw substitutes `${DOMONDA_API_KEY}` from the environment at runtime.
+
+For local development, set `DOMONDA_URL` in your `.env` and update the `url`
+field accordingly:
+
+```json
+{
+  "mcpServers": {
+    "domonda": {
+      "url": "${DOMONDA_URL}/api/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${DOMONDA_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### 4. Verify connectivity
+
+Run the included health check:
+
+```bash
+./scripts/health_check.sh
+```
+
+Expected output:
+
+```
+Checking https://domonda.app/api/mcp/ ...
+OK (HTTP 200)
+```
+
+The script sources `.env` automatically, sends an MCP `initialize` request,
+and reports the HTTP status code.
+
+## Usage
+
+Once installed, your OpenClaw agent can call any of the 28 domonda tools.
+See `SKILL.md` for the complete tool reference with parameters.
+
+### Recommended first steps
+
+1. **`list_capabilities`** — When unsure which tool fits, get a grouped
+   catalog of all available tools first.
+2. **`get_my_company`** — Confirm authentication and see which company the
+   API key is scoped to.
+3. **`list_tables`** / **`describe_table`** — Explore the available database
+   schema before writing queries.
+4. **`list_documents`** or **`list_invoices`** — Browse recent data.
+5. **`execute_query`** — Run ad-hoc read-only SQL for anything the specialized
+   tools don't cover.
+
+### Tool categories
+
+| Category  | Tools                                                                                                                                                    |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Discovery | `list_capabilities`                                                                                                                                      |
+| Schema    | `list_tables`, `describe_table`                                                                                                                          |
+| Query     | `execute_query`                                                                                                                                          |
+| Documents | `list_documents`, `get_document`, `get_document_fulltext`, `search_documents`, `download_document_pdf`, `get_document_thumbnail`, `get_document_preview`, `add_document` (write) |
+| Invoices  | `list_invoices`, `get_invoice`                                                                                                                           |
+| Payments  | `list_money_accounts`, `list_money_transactions`, `get_invoice_payments`                                                                                 |
+| Company   | `get_my_company`, `list_document_categories`, `list_gl_accounts`, `list_partner_companies`                                                               |
+| User      | `get_user`                                                                                                                                               |
+| Workflows | `list_document_workflows`, `list_document_workflow_steps`, `list_document_workflow_states`                                                               |
+| App URLs  | `get_app_urls`, `get_document_urls`, `get_document_selection_url`                                                                                        |
+
+### Example prompts for your agent
+
+- "Show me all invoices from January 2026 over €1,000"
+- "Download the PDF for document 8a2f..."
+- "Which GL accounts are in use?"
+- "Search documents for 'electricity bill'"
+- "Run a query to find the top 10 partners by invoice count"
+
+## Authentication
+
+The domonda MCP server uses **Streamable HTTP** transport with **Bearer token**
+authentication. Two token types are supported:
+
+1. **API key (HS256 JWT)** — the standard domonda API key. The JWT `sub` claim
+   identifies the client company directly. This is the simplest option for
+   programmatic access.
+2. **OAuth (Auth0 RS256)** — an Auth0 access token issued for the MCP resource.
+   The token's Auth0 `sub` claim is mapped to a Domonda user, who must be
+   enabled and have access to the target company. Supports the
+   `X-Selected-Client-Company-ID` header for multi-company users. Clients that
+   support OAuth discovery will be guided automatically via the
+   `WWW-Authenticate` header and the `.well-known/oauth-protected-resource`
+   metadata endpoint (RFC 9728).
+
+```
+Authorization: Bearer <DOMONDA_API_KEY_OR_OAUTH_TOKEN>
+```
+
+The server enforces:
+
+- **Read-only transactions for query tools** — no INSERT, UPDATE, DELETE, or DDL through `execute_query` or any specialized query tool
+- **Schema restriction** — only the `api` schema is accessible
+- **Row limit** — max 1,000 rows per query
+- **Query timeout** — 30-second default
+- **Query length** — max 10,000 characters
+- **Writes are limited to `add_document`** — processed through the same OCR, duplicate-detection, and category-ownership checks as the public REST upload endpoint
+
+## Troubleshooting
+
+| Symptom                         | Cause                                      | Fix                                                  |
+|---------------------------------|--------------------------------------------|------------------------------------------------------|
+| `Error: DOMONDA_API_KEY is not set` | Missing API key                        | Set `DOMONDA_API_KEY` in `.env` or your environment  |
+| HTTP 401                        | Invalid, expired, or blocked token         | Verify your API key or OAuth token; contact admin if blocked |
+| HTTP 403                        | Forbidden company access or insufficient OAuth scopes | Check the selected company or required scopes        |
+| HTTP 404                        | Wrong endpoint URL                         | Ensure the URL ends with `/api/mcp/` or `/api/mcp`             |
+| Query returns no rows           | Company scoping — data belongs to another company | Confirm `get_my_company` returns the expected company |
+| `execute_query` rejected        | SQL validation failed (DML, wrong schema)  | Use only SELECT/WITH against the `api` schema        |

--- a/mcp/openclaw/SKILL.md
+++ b/mcp/openclaw/SKILL.md
@@ -1,0 +1,560 @@
+---
+name: domonda
+description: >
+  Use when you need to access domonda financial data — documents, invoices,
+  payments, money transactions, companies, GL accounts, partner companies,
+  and document workflows. Connects to the domonda MCP server via Streamable
+  HTTP with Bearer token authentication (API key or OAuth). All query tools
+  are read-only; the only write tool is `add_document`, which uploads a file
+  into the authenticated company's document pipeline.
+env:
+  - name: DOMONDA_API_KEY
+    required: true
+    secret: true
+    description: API key (HS256 JWT) or Auth0 OAuth access token for Bearer authentication
+  - name: DOMONDA_URL
+    required: false
+    secret: false
+    description: "Override domonda base URL (default: https://domonda.app)"
+---
+
+# domonda MCP Skill
+
+Connect to the [domonda](https://domonda.app) financial data platform via its MCP server.
+Query documents, invoices, payments, money transactions, companies, GL accounts, partner companies, and document workflows. All query tools are read-only; the only write tool is `add_document`, which uploads a file into the authenticated company's document pipeline.
+
+> **Language note.** The live MCP tool and parameter descriptions surfaced by
+> the server are written in **German**, including a "Nutzen wenn …" block of
+> trigger phrases. This matches the domonda-app UI and the natural vocabulary
+> of end users, and improves discoverability for clients (e.g. ChatGPT) that
+> match user prompts against tool descriptions by embedding similarity. The
+> English descriptions in this file are developer-facing reference only —
+> what your agent actually sees at runtime is the German text from the server.
+>
+> If you are unsure which tool to call, call `list_capabilities` first to get
+> a topic-grouped catalog of all available tools.
+
+## Agent Security Rules
+
+- **Never** display, log, or transmit the API key in plain text.
+- **Never** pass the API key as a CLI argument or embed it in URLs.
+- Only use the API key for authenticating against the domonda MCP endpoint.
+- Do not write, modify, or delete data via `execute_query` or any query tool — those tools are read-only and any DML will be rejected by the server.
+- The only write tool is `add_document`. Only call it when the user has explicitly asked you to upload a document. Never call it on your own initiative, and never use it to write arbitrary data.
+
+## Quick Start
+
+1. Create a `.env` file with your API key:
+
+   ```
+   DOMONDA_API_KEY=your-jwt-api-key-here
+   ```
+
+2. Configure `openclaw.json` with the domonda MCP server:
+
+   ```json
+   {
+     "mcpServers": {
+       "domonda": {
+         "url": "https://domonda.app/api/mcp/",
+         "headers": {
+           "Authorization": "Bearer ${DOMONDA_API_KEY}"
+         }
+       }
+     }
+   }
+   ```
+
+3. Run the health check to verify connectivity:
+
+   ```bash
+   ./scripts/health_check.sh
+   ```
+
+## Available Tools
+
+> The description paragraph for each tool below is written in **German**
+> (matching what the running MCP server actually surfaces to clients),
+> because domonda end users chat in German and tools are picked by
+> similarity to the user's prompt. The parameter tables and technical
+> notes stay in English.
+
+### Discovery
+
+#### `list_capabilities`
+
+Liefert einen nach Thema gruppierten Katalog ALLER verfügbaren Domonda-Tools
+mit einer kurzen deutschen Einzeiler-Beschreibung pro Tool. Dient als
+Einstiegspunkt: bei Unsicherheit, welches Tool passt, zuerst dieses
+aufrufen und dann das passende Tool direkt nutzen. Nutzen wenn der Benutzer
+nach "was kannst du", "welche Tools", "welche Werkzeuge", "hilf mir",
+"Übersicht", "Katalog", "was ist verfügbar", "Capabilities", "Hilfe" fragt.
+
+**Parameters:** None
+
+### Schema Tools
+
+#### `list_tables`
+
+Listet alle Tabellen und Views im `api`-Schema der Domonda-Datenbank (Name,
+Typ Tabelle/View, Beschreibung). Nutzen für Datenmodell-Exploration, bevor
+eine benutzerdefinierte Abfrage via `execute_query` gebaut wird, oder wenn
+der Benutzer nach "welche Tabellen gibt es", "Datenmodell", "Schema", "was
+ist in der DB" fragt.
+
+**Parameters:** None
+
+#### `describe_table`
+
+Beschreibt die Spalten einer Tabelle oder View im `api`-Schema:
+Spaltennamen, Datentypen, NULL-Zulässigkeit, Default-Werte. Nutzen bevor
+eine `SELECT`-Abfrage via `execute_query` geschrieben wird, um die
+verfügbaren Spalten zu kennen, oder wenn der Benutzer nach "welche
+Spalten", "Struktur der Tabelle", "Felder" fragt.
+
+| Parameter    | Type   | Required | Description                                                                                     |
+|------------- |--------|----------|-------------------------------------------------------------------------------------------------|
+| `table_name` | string | yes      | Name of the table or view in the `api` schema (e.g. `invoice`, `document`, `partner_company`)   |
+
+### Query Tools
+
+#### `execute_query`
+
+Führt eine READ-ONLY SQL-Abfrage (`SELECT` oder `WITH`) gegen das
+`api`-Schema der Domonda-Datenbank aus. Nur das `api`-Schema ist zugänglich;
+`pg_catalog`, `information_schema` und andere Schemata werden abgelehnt.
+Unqualifizierte Tabellennamen werden ins `api`-Schema aufgelöst. Ergebnis:
+JSON-Array von Objekten, maximal 1000 Zeilen. Daten sind automatisch auf
+den angemeldeten Mandanten eingeschränkt. Nutzen nur wenn die
+spezialisierten Tools (`list_documents`, `list_invoices`,
+`list_money_transactions`, …) nicht ausreichen und eine eigene Abfrage
+nötig ist. Vorher `list_tables` und `describe_table` nutzen, um das Schema
+zu erkunden.
+
+| Parameter | Type   | Required | Description                                                                                        |
+|-----------|--------|----------|----------------------------------------------------------------------------------------------------|
+| `sql`     | string | yes      | The SQL query to execute. Must start with `SELECT` or `WITH`. Only the `api` schema is accessible. |
+
+### Document Tools
+
+#### `list_documents`
+
+Sucht, filtert und listet Dokumente des Mandanten: Rechnungen, Verträge,
+Belege, Lieferscheine, Kontoauszüge, sonstige Dokumente, DMS. Unterstützt
+Volltextsuche, Datumsbereiche (mehrere Datumstypen), Beträge, Zahl- und
+Exportstatus, Geschäftspartner, Kategorien, Dokumentarten,
+Genehmigungsstatus, Duplikate, Kommentare, Vertragstypen und konfigurierbare
+Sortierung. Nutzen wenn der Benutzer nach "Dokumente", "Belege",
+"Rechnungen", "Verträge", "Lieferscheine", "Kontoauszüge", "Mahnungen",
+"was liegt im Eingang", "Dokumentenliste", "welche Dokumente gibt es zu …",
+"suche Beleg über …", "offene Rechnungen", "nicht freigegebene", "nicht
+exportierte" fragt. Für reine Volltextsuche ohne Filter siehe
+`search_documents`.
+
+All filter parameters are optional; omitting a parameter lets the server default apply.
+
+| Parameter                | Type            | Description                                                                                                               |
+|--------------------------|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| `limit`                  | number          | Maximum number of documents to return (default 50, max 1000)                                                              |
+| `offset`                 | number          | Number of documents to skip for pagination                                                                                |
+| `search_text`            | string          | Fulltext search over the extracted document content (OCR + structured data)                                               |
+| `archived`               | string enum     | `exclude` (default, only active), `only` (only archived), or `include` (both)                                             |
+| `has_warning`            | boolean         | `true`: only documents with a warning; `false`: only documents without                                                    |
+| `internal_number`        | string          | Filter by domonda-internal sequential document number                                                                     |
+| `date_filter_type`       | string enum     | Which date `from_date`/`until_date` apply to: `DOCUMENT_DATE`, `INVOICE_DATE` (default), `IMPORT_DATE`, `DUE_DATE`, `DISCOUNT_DUE_DATE`, `PAID_DATE`, `DELIVERED_DATE` |
+| `from_date`              | string          | Lower bound (inclusive) for the date selected via `date_filter_type` (YYYY-MM-DD)                                         |
+| `until_date`             | string          | Upper bound (inclusive) for the date selected via `date_filter_type` (YYYY-MM-DD)                                         |
+| `min_total`              | number          | Only documents with invoice gross total ≥ this amount                                                                     |
+| `max_total`              | number          | Only documents with invoice gross total ≤ this amount                                                                     |
+| `export_status`          | string enum     | Accounting export status (exported / not exported, for "booking" or "ready for booking"; see tool schema for the full enum) |
+| `paid_status`            | string enum     | Invoice payment status: paid, partially paid, not paid, not payable, or paid via a specific payment method                 |
+| `document_types`         | string[] enum   | One or more document types (incoming/outgoing invoice, dunning letter, delivery note, bank/credit-card statement, other document, DMS, …) |
+| `document_category_ids`  | string[] (UUID) | One or more document category IDs (from `list_document_categories`)                                                        |
+| `partner_company_ids`    | string[] (UUID) | One or more partner company IDs (customer or supplier, from `list_partner_companies`)                                      |
+| `is_credit_memo`         | boolean         | `true`: only credit memos (Gutschriften); `false`: exclude credit memos                                                    |
+| `has_pain001_payment`    | boolean         | `true`: only documents with a generated SEPA credit transfer (PAIN.001); `false`: without                                  |
+| `has_pain008_direct_debit` | boolean       | `true`: only documents with a generated SEPA direct debit (PAIN.008); `false`: without                                     |
+| `is_payment_reminder_sent` | boolean       | `true`: only documents for which a payment reminder/dunning letter has already been sent                                   |
+| `is_approved`            | boolean         | `true`: only approved documents; `false`: only not-yet-approved documents (waiting for workflow approval)                  |
+| `is_duplicate`           | boolean         | `true`: only documents detected as duplicates; `false`: only non-duplicates                                                |
+| `has_comments`           | boolean         | `true`: only documents with comments; `false`: without                                                                     |
+| `is_recurring`           | boolean         | `true`: only recurring documents; `false`: only one-off documents                                                          |
+| `contract_type`          | string enum     | Contract type filter for `OTHER_DOCUMENT`s (service contracts, rental contracts, insurance, …; see tool schema)            |
+| `order_bys`              | string[] enum   | Ordering rules applied in sequence; default `IMPORT_DATE_DESC` (most recently imported first)                              |
+
+> The full enum values for `export_status`, `paid_status`, `document_types`, `contract_type`, and `order_bys` are exposed on the live tool schema — your MCP client will surface them.
+
+#### `get_document`
+
+Liefert Metadaten eines einzelnen Dokuments anhand seiner UUID: Dokumentart,
+Kategorie, Geschäftspartner, Datum, Status, Beträge (soweit vorhanden).
+Enthält **nicht** den Volltext — siehe `get_document_fulltext` für den
+extrahierten OCR-Text oder `get_invoice` für Rechnungs-Positionen. Nutzen
+wenn der Benutzer nach "Details zum Dokument", "Info zu diesem Beleg", "was
+ist das für ein Dokument", "wer hat das hochgeladen", "welche Kategorie"
+fragt.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_fulltext`
+
+Liefert den extrahierten Volltext (OCR) eines Dokuments. Nutzen wenn der
+Benutzer den kompletten Inhalt eines Dokuments lesen will — "Volltext",
+"was steht im Beleg", "OCR-Text", "Inhalt dieses Dokuments".
+
+**Warning:** fulltexts can be very large; long documents may approach or
+exceed the MCP response byte cap (default 10 MiB)
+and the call will fail. For pure search prefer `search_documents` and only
+fetch the fulltext of a specific hit when really needed.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `search_documents`
+
+Volltextsuche über alle Dokumente des Mandanten; Treffer sind nach Relevanz
+sortiert. Nutzen wenn der Benutzer etwas FINDEN will, statt gezielt zu
+filtern — z. B. "finde Beleg über Büromöbel", "such mir alles zu Projekt
+X", "gibt es eine Rechnung mit …", "wo taucht der Begriff … auf". Für
+strukturierte Filter (Datum, Partner, Status, Beträge) lieber
+`list_documents` verwenden.
+
+| Parameter | Type   | Required | Description                                          |
+|-----------|--------|----------|------------------------------------------------------|
+| `query`   | string | yes      | Search term or phrase for the fulltext search        |
+| `limit`   | number | no       | Maximum number of results (default: 20, max: 1000)   |
+
+#### `download_document_pdf`
+
+Lädt die Original-PDF-Datei eines Dokuments herunter — optional mit
+angehängtem oder vorangestelltem Audit-Trail (Protokoll der
+Bearbeitungsschritte, Freigaben, Änderungen). Standard: die PDF-Bytes
+werden base64-kodiert inline zurückgegeben. Mit `inline: false` wird
+stattdessen ein MCP `resource_link` auf `document://{document_id}/pdf?...`
+geliefert, den ein resource-fähiger Client via `resources/read` nachladen
+kann. Nutzen wenn der Benutzer "die PDF", "das Original", "den Beleg
+herunterladen", "Rechnung als PDF", "mit Audit-Trail" sagt.
+
+| Parameter          | Type    | Required | Description                                                                        |
+|--------------------|---------|----------|------------------------------------------------------------------------------------|
+| `document_id`      | string  | yes      | The UUID of the document                                                           |
+| `audit_trail`      | string  | no       | Audit-trail position in the PDF: `append`, `prepend`, `configured` (mandant setting), or `only` (audit trail only). Empty = no audit trail. |
+| `audit_trail_lang` | string  | no       | Language of the audit trail as ISO 639-1 code (default `de`)                       |
+| `inline`           | boolean | no       | `true` (default): return the PDF bytes inline as a base64-encoded resource. `false`: return an MCP `resource_link` to `document://{document_id}/pdf?...` that a resource-aware client loads via `resources/read`. |
+
+The PDF is also exposed as an MCP resource at `document://{document_id}/pdf{?audit_trail,audit_trail_lang}`, so resource-aware clients can fetch it via `resources/read`. The `configured` audit-trail value is resolved to `append`/`prepend` before a resource link is returned, so resource URIs are deterministic and cacheable.
+
+#### `get_document_thumbnail`
+
+Liefert die kleine Miniaturansicht (JPEG, 256 px breit, Seitenverhältnis
+erhalten) eines Dokuments als base64-kodierten Blob. Auch als MCP-Ressource
+unter `document://{document_id}/thumb_256x0.jpeg` verfügbar. Nutzen wenn
+der Benutzer eine schnelle Vorschau, ein Miniaturbild oder ein "Icon" eines
+Dokuments sehen will. Für eine größere Vorschau siehe `get_document_preview`.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_preview`
+
+Liefert die große Vorschau (JPEG, 964×1364) eines Dokuments als
+base64-kodierten Blob — das größte vorgerenderte Vorschaubild. Auch als
+MCP-Ressource unter `document://{document_id}/preview.jpeg` verfügbar.
+Nutzen wenn der Benutzer "zeig mir das Dokument", "Vorschau", "wie sieht
+der Beleg aus", "Bild des Dokuments" sagt. Für eine kleinere Miniaturansicht
+siehe `get_document_thumbnail`; für die Original-PDF siehe
+`download_document_pdf`.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `add_document` (write)
+
+Lädt ein neues Dokument (Rechnung, Beleg, Vertrag, Lieferschein, sonstige
+Datei) für den angemeldeten Mandanten hoch. Dubletten-Erkennung und
+Kategorie-Zuweisung laufen automatisch. Nutzen wenn der Benutzer "Dokument
+hochladen", "Beleg importieren", "Rechnung hinzufügen", "upload", "neues
+Dokument", "Datei einspielen" sagt. Vorher `list_document_categories`
+aufrufen, um eine gültige `category_id` zu ermitteln.
+
+Supported file types: PDF, PNG, JPEG, TIFF, XML, HTML, RTF, DOC, DOCX, ODT,
+XLS, XLSX, ODS. This is the **only write operation** on the MCP server; the
+file is processed through the same pipeline as the public upload endpoint.
+Returns the new document UUID on success.
+
+| Parameter                 | Type    | Required | Description                                                                                |
+|---------------------------|---------|----------|--------------------------------------------------------------------------------------------|
+| `file_data`               | string  | yes      | Base64-encoded file content (no URL, no path — the raw bytes base64-encoded)                |
+| `filename`                | string  | yes      | Original filename including extension (e.g. `invoice_2026_04.pdf`)                         |
+| `category_id`             | string  | yes      | Document category UUID (use `list_document_categories` to find valid IDs)                  |
+| `tags`                    | string[]| no       | Optional document tags                                                                     |
+| `allow_duplicate_deleted` | boolean | no       | If `true`, allow re-uploading a file whose hash matches a previously-deleted document. Default `false`. |
+| `wait_for_extraction`     | boolean | no       | If `true`, wait synchronously for OCR/extraction before returning. Default `false` (asynchronous). |
+
+> **Agent guidance:** Only call `add_document` when the user has explicitly asked you to upload a file. Do not use it on your own initiative.
+
+### Invoice Tools
+
+#### `list_invoices`
+
+Listet Rechnungen des Mandanten (Eingangs- und Ausgangsrechnungen, inkl.
+Gutschriften) mit Rechnungsnummer, Rechnungsdatum, Fälligkeitsdatum,
+Geschäftspartner, Netto, Brutto, Währung, USt-Satz, Zahlstatus, offenem
+Betrag und Buchungsstatus. Filter: Datumsbereich, Partner-Name,
+Mindest-/Maximalbetrag. Nutzen wenn der Benutzer nach "Rechnungen",
+"Eingangsrechnungen", "Ausgangsrechnungen", "ER", "AR", "Gutschriften",
+"offene Posten", "Forderungen", "Verbindlichkeiten", "unbezahlte
+Rechnungen", "Rechnungen von <Firma>" fragt. Für einzelne Rechnungsdetails
+siehe `get_invoice`.
+
+| Parameter      | Type   | Required | Description                                                                                                  |
+|----------------|--------|----------|--------------------------------------------------------------------------------------------------------------|
+| `limit`        | number | no       | Maximum number of invoices to return (default: 50, max: 1000)                                                |
+| `offset`       | number | no       | Number of invoices to skip for pagination (default: 0)                                                       |
+| `from_date`    | string | no       | Lower bound (inclusive) for the invoice date (YYYY-MM-DD)                                                    |
+| `until_date`   | string | no       | Upper bound (inclusive) for the invoice date (YYYY-MM-DD)                                                    |
+| `partner_name` | string | no       | Filter by partner company name (customer or supplier, case-insensitive partial match)                        |
+| `min_total`    | number | no       | Only invoices with gross total ≥ this amount                                                                 |
+| `max_total`    | number | no       | Only invoices with gross total ≤ this amount                                                                 |
+
+#### `get_invoice`
+
+Liefert alle Details zu einer einzelnen Rechnung: Kopfdaten, Positionen
+(Line Items), Skonto, Fälligkeit, umgerechnete EUR-Beträge, Geschäftspartner,
+UID/VAT-ID des Partners, zugeordnete Zahlungen. Nutzen wenn der Benutzer
+eine konkrete Rechnung im Detail sehen will — "zeig mir Rechnung …",
+"Details zu dieser Rechnung", "was steht auf der Rechnung", "Positionen",
+"Line Items", "Skonto", "Fälligkeit". Für eine Liste mehrerer Rechnungen
+siehe `list_invoices`.
+
+| Parameter     | Type   | Required | Description                                                                   |
+|---------------|--------|----------|-------------------------------------------------------------------------------|
+| `document_id` | string | yes      | The UUID of the invoice's document (from `list_invoices` or `list_documents`) |
+
+### Payment Tools
+
+#### `list_money_accounts`
+
+Listet alle Bankkonten und Zahlungskonten des Mandanten: Bankkonten,
+Kreditkarten, PayPal, Wise, Kassa. Nutzen wenn der Benutzer nach
+"Bankkonto", "Bankkonten", "Konten", "Kreditkarte", "PayPal", "Kassa",
+"welche Konten haben wir", "IBAN" fragt — oder wenn eine Kontoauswahl für
+weitere Filter benötigt wird.
+
+**Parameters:** None
+
+#### `list_money_transactions`
+
+Listet Banktransaktionen und Kreditkartenbewegungen des Mandanten mit
+Betrag, Währung, Buchungsdatum, Valutadatum, Empfänger/Zahler,
+Verwendungszweck und Typ (EINGEHEND/AUSGEHEND). Filter: Konto, Typ,
+Datumsbereich, Partner-Name. Nutzen wenn der Benutzer nach "Transaktionen",
+"Banktransaktionen", "Buchungen auf dem Konto", "Kontoauszug", "Ein- und
+Ausgänge", "Zahlungseingang", "Zahlungsausgang", "Umsätze" fragt.
+
+| Parameter      | Type   | Required | Description                                                           |
+|----------------|--------|----------|-----------------------------------------------------------------------|
+| `limit`        | number | no       | Maximum number of transactions to return (default: 50, max: 1000)     |
+| `offset`       | number | no       | Number of transactions to skip for pagination (default: 0)            |
+| `account_id`   | string | no       | Filter to a specific money account (UUID from `list_money_accounts`)  |
+| `type`         | string | no       | Filter by direction: `INCOMING` (credit) or `OUTGOING` (debit)        |
+| `from_date`    | string | no       | Lower bound (inclusive) for the booking date (YYYY-MM-DD)             |
+| `until_date`   | string | no       | Upper bound (inclusive) for the booking date (YYYY-MM-DD)             |
+| `partner_name` | string | no       | Text filter on the counterparty name (case-insensitive partial match) |
+
+#### `get_invoice_payments`
+
+Liefert alle Zahlungen (Banktransaktionen), die einer bestimmten Rechnung
+zugeordnet sind, inkl. offenem Betrag, bereits verrechneter Summe,
+Zahlstatus und Zahldatum. Nutzen wenn der Benutzer nach "Zahlungen zur
+Rechnung", "ist bezahlt", "offener Betrag", "welche Zahlung wurde
+zugeordnet", "Zahlungsabgleich", "Payment Matching" für eine konkrete
+Rechnung fragt.
+
+| Parameter     | Type   | Required | Description                                                                   |
+|---------------|--------|----------|-------------------------------------------------------------------------------|
+| `document_id` | string | yes      | The UUID of the invoice's document (from `list_invoices` or `list_documents`) |
+
+### Company Tools
+
+#### `get_my_company`
+
+Liefert die Stammdaten des eigenen Mandanten (angemeldete Firma):
+Firmenname, Rechtsform, Hauptsitz/Adresse, Telefon, E-Mail, Website,
+UID/VAT-Nummer, Steuernummer, Handelsregister-Nummer. Nutzen wenn der
+Benutzer nach "meine Firma", "mein Mandant", "unsere Firma", "Firmendaten",
+"Stammdaten", "UID", "VAT-ID", "Steuernummer", "Firmenadresse", "Hauptsitz",
+"wer sind wir" fragt.
+
+**Parameters:** None
+
+#### `list_document_categories`
+
+Listet alle Dokumentenkategorien des Mandanten (visuelle Kategorien für
+die Ablage). Nutzen wenn der Benutzer nach "Kategorien",
+"Dokumentenkategorien", "Ablagekategorien", "welche Kategorien gibt es",
+"wo wird abgelegt" fragt oder bevor ein Dokument via `add_document`
+hochgeladen wird, um eine gültige `category_id` zu ermitteln.
+
+**Parameters:** None
+
+#### `list_gl_accounts`
+
+Listet alle Sachkonten (GL accounts, Hauptbuchkonten) des Mandanten mit
+Nummer und Bezeichnung. Nutzen wenn der Benutzer nach "Sachkonto",
+"Sachkonten", "Kontenplan", "Buchungskonto", "GL account", "general
+ledger", "Hauptbuch", "Kontonummer" fragt — typischerweise für
+Buchhaltung, Kontierung und Accounting-Export.
+
+**Parameters:** None
+
+#### `list_partner_companies`
+
+Listet Geschäftspartner des Mandanten: Kunden, Lieferanten, Debitoren,
+Kreditoren — mit Namen, abgeleitetem Namen, Debitoren- und
+Kreditoren-Kontonummer. Optional nach Namen filterbar. Nutzen wenn der
+Benutzer nach "Kunde", "Kunden", "Lieferant", "Lieferanten",
+"Geschäftspartner", "Partner", "Debitor", "Kreditor", "vendor",
+"supplier", "customer" fragt.
+
+| Parameter     | Type   | Required | Description                                                                                    |
+|---------------|--------|----------|------------------------------------------------------------------------------------------------|
+| `search_text` | string | no       | Optional text filter: partner companies whose name contains this substring (case-insensitive)  |
+| `limit`       | number | no       | Maximum number of results (default: 50, max: 1000)                                             |
+
+### User Tools
+
+#### `get_user`
+
+Liefert den aktuell angemeldeten Benutzer (Name, E-Mail, Sprache, Mandant).
+Nutzen wenn der Benutzer nach "wer bin ich", "mein Profil", "mein Konto",
+"Benutzer", "User", "angemeldet" fragt oder wenn ein anderes Tool die
+aktuelle Benutzer-ID benötigt. Funktioniert nur bei OAuth-Login —
+API-Key-Zugriff liefert hier einen Fehler, weil der Key einen Mandanten
+identifiziert, keinen Benutzer.
+
+**Parameters:** None
+
+### Workflow Tools
+
+#### `list_document_workflows`
+
+Listet alle im Mandanten konfigurierten Dokument-Workflows
+(Freigabe-Prozesse) mit Namen und IDs. Ein Workflow ist ein Ablauf, den
+ein Dokument durchläuft, bestehend aus mehreren Workflow-Schritten. Nutzen
+wenn der Benutzer nach "Workflows", "Freigabe-Prozess",
+"Genehmigungsprozess", "Approval-Flow", "welche Workflows gibt es" fragt.
+Für die einzelnen Schritte eines Workflows siehe
+`list_document_workflow_steps`.
+
+| Parameter | Type   | Required | Description                                                |
+|-----------|--------|----------|------------------------------------------------------------|
+| `limit`   | number | no       | Maximum number of rows to return (default: 100, max: 1000) |
+| `offset`  | number | no       | Number of rows to skip for pagination (default: 0)         |
+
+#### `list_document_workflow_steps`
+
+Listet Workflow-Schritte des Mandanten (einzelne Stationen eines
+Freigabe-Workflows). Ein Dokument steht zu jedem Zeitpunkt in genau einem
+Workflow-Schritt. Nutzen wenn der Benutzer nach "Workflow-Schritten",
+"Freigabeschritten", "Genehmigungsstufen", "welche Schritte hat unser
+Workflow", "Approval-Steps" fragt. Für den aktuellen Schritt konkreter
+Dokumente siehe `list_document_workflow_states`.
+
+| Parameter     | Type   | Required | Description                                                                                   |
+|---------------|--------|----------|-----------------------------------------------------------------------------------------------|
+| `workflow_id` | string | no       | Optional: UUID of a specific workflow to list only its steps (from `list_document_workflows`) |
+| `limit`       | number | no       | Maximum number of rows to return (default: 100, max: 1000)                                    |
+| `offset`      | number | no       | Number of rows to skip for pagination (default: 0)                                            |
+
+#### `list_document_workflow_states`
+
+Liefert den AKTUELLEN Workflow-Zustand von Dokumenten: in welchem
+Workflow-Schritt steht ein Dokument gerade, und wie lautet sein Status.
+Eine Zeile pro Dokument. Nutzen wenn der Benutzer nach "Wo steht das
+Dokument gerade", "in welchem Schritt", "Freigabestatus", "wartet auf
+Freigabe von …", "welche Dokumente hängen wo", "Workflow-Status" fragt.
+
+| Parameter     | Type   | Required | Description                                                            |
+|---------------|--------|----------|------------------------------------------------------------------------|
+| `document_id` | string | no       | Optional: UUID of a single document to return only its workflow state  |
+| `limit`       | number | no       | Maximum number of rows to return (default: 50, max: 1000)              |
+| `offset`      | number | no       | Number of rows to skip for pagination (default: 0)                     |
+
+### App URL Tools
+
+#### `get_app_urls`
+
+Liefert Deep-Links in die Domonda Web-App, zugeschnitten auf den
+angemeldeten Mandanten: Dokumente-Übersicht, Bank (Banking),
+Buchhaltungsansicht, Workflows/Freigaben, Academy (Hilfe/Doku),
+API-Repository. Nutzen wenn der Benutzer "öffne in Domonda", "zeig mir in
+der App", "Link zu …", "wo finde ich das", "geh in die Bank-Ansicht",
+"geh in die Buchhaltung" sagt.
+
+- `documents_overview` — main documents list
+- `banking` — banking overview
+- `accounting` — documents list with accounting view
+- `workflows` — documents list with workflow view (unapproved)
+- `documentation` — user-facing documentation (academy)
+- `api` — public API repository
+
+**Parameters:** None
+
+#### `get_document_urls`
+
+Liefert Deep-Links in die Domonda Web-App für EIN einzelnes Dokument: Tabs
+Prüfung (`review`), Zahlung (`payment`), Buchhaltung (`accounting`) und
+Zusammenarbeit (`collaboration`). Nutzen wenn der Benutzer "öffne dieses
+Dokument in Domonda", "Link zum Beleg", "spring zu
+Zahlung/Buchhaltung/Prüfung" für ein konkretes Dokument sagt. Das Dokument
+muss zum angemeldeten Mandanten gehören.
+
+| Parameter     | Type   | Required | Description              |
+|---------------|--------|----------|--------------------------|
+| `document_id` | string | yes      | The UUID of the document |
+
+#### `get_document_selection_url`
+
+Liefert Deep-Links in die Domonda Web-App, die eine Auswahl MEHRERER
+Dokumente gemeinsam öffnen — je eine URL pro Mehrfach-Ansicht:
+`thumb_view` (Miniaturansicht), `list_view` (Listenansicht),
+`accounting_view` (Buchhaltungsansicht), `workflow_view` (Freigabenansicht).
+Nutzen wenn der Benutzer "öffne diese Rechnungen in Domonda", "zeig mir
+diese Belege in der App", "Link zu diesen Dokumenten",
+"Buchhaltungsansicht für diese Dokumente" sagt. Alle Dokumente müssen zum
+angemeldeten Mandanten gehören.
+
+URLs use the `?documentRowIds[]=<uuid>&view=<VIEW>` schema consumed by the
+domonda-app frontend routing; document ownership is verified per-id on the
+server.
+
+| Parameter      | Type            | Required | Description                                                              |
+|----------------|-----------------|----------|--------------------------------------------------------------------------|
+| `document_ids` | string[] (UUID) | yes      | List of document UUIDs to open together in the selection (at least one) |
+
+## Authentication
+
+The domonda MCP server uses JWT Bearer token authentication. The API key is a JWT where the `sub` claim contains the client company ID. All queries execute within a read-only, company-scoped database transaction.
+
+Pass the token in the HTTP `Authorization` header:
+
+```
+Authorization: Bearer <your-api-key>
+```
+
+## Usage Tips
+
+- Start with `get_my_company` to confirm connectivity and see which company you are authenticated as.
+- Use `list_tables` and `describe_table` for schema discovery before writing queries.
+- Use `execute_query` for ad-hoc SQL queries when the specialized tools don't cover your use case.
+- All date parameters use `YYYY-MM-DD` format.
+- UUID parameters must be valid UUID strings.
+- Results are capped at 1000 rows — use `limit` and `offset` for pagination.
+- `offset` is clamped to 100,000; stream beyond that by narrowing filters (date range, partner, status) instead of paginating deeper.
+- `execute_query` rejects SQL longer than 10,000 characters.

--- a/mcp/openclaw/openclaw.json.example
+++ b/mcp/openclaw/openclaw.json.example
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "domonda": {
+      "url": "https://domonda.app/api/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${DOMONDA_API_KEY}"
+      }
+    }
+  }
+}

--- a/mcp/openclaw/scripts/health_check.sh
+++ b/mcp/openclaw/scripts/health_check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source .env if present
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+DOMONDA_URL="${DOMONDA_URL:-https://domonda.app}"
+MCP_ENDPOINT="${DOMONDA_URL}/api/mcp/"
+
+if [ -z "${DOMONDA_API_KEY:-}" ]; then
+  echo "Error: DOMONDA_API_KEY is not set."
+  echo "Set it in your environment or in .env"
+  exit 1
+fi
+
+echo "Checking ${MCP_ENDPOINT} ..."
+
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer ${DOMONDA_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"health-check","version":"1.0.0"}}}' \
+  "${MCP_ENDPOINT}")
+
+if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+  echo "OK (HTTP ${HTTP_STATUS})"
+else
+  echo "FAILED (HTTP ${HTTP_STATUS})"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Documents the Domonda **MCP server** (AI assistant access over the [Model Context Protocol](https://modelcontextprotocol.io), Streamable HTTP at `https://domonda.app/api/mcp/`) as a fourth interface alongside GraphQL and REST.

This is the public-facing documentation; it deliberately omits internal operator detail (Auth0 tenant setup, server env vars, the internal threat-model doc).

## What's added

- **`mcp/README.md`** — overview: authentication (the same Bearer API key as GraphQL/REST, plus interactive OAuth), tool list, resources, curl examples, and limits.
- **Per-client setup guides** under `mcp/`:
  - `claude-code/` — Anthropic's CLI / IDE agent (native HTTP MCP)
  - `claude-desktop/` — Claude Desktop, Cowork, claude.ai (Custom Connector UI)
  - `chatgpt/` — ChatGPT developer-mode connector + OpenAI Responses API / Agents SDK
  - `openclaw/` — OpenClaw skill / plugin
  - each with a `SKILL.md` tool reference, a config example, and a `scripts/health_check.sh` connectivity check.
- **README** — new "MCP Server (AI assistant access)" section + Table of Contents entry; intro updated to "three complementary interfaces".

## Notes

- All query tools are read-only; the only write tool is `add_document`, which reuses the public REST upload pipeline.
- Tool/parameter descriptions surfaced by the live server are in German (end users chat in German); the English text in these guides is reference only.
- One-time curated copy of the docs that live next to the server in `domonda-service`. If maintaining it by hand drifts, an automated publish is the upgrade path.
